### PR TITLE
fix(README.md): Manuals installation path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It doesn't do much, except it will color most of the HTML blocks and give you so
 
 ### Manuals installation requirements
 
-Be sure to install the manual for your application to `/usr/share/dman/<Application-Name>/<Language-Code>/`.
+Be sure to install the manual for your application to `/usr/share/deepin-manual/manual/<Application-Name>/<Language-Code>/`.
 
 ### Invocation
 


### PR DESCRIPTION
/usr/share/deepin-manual/manual
```shell
pikachu@pikachu-PC:/usr/share/deepin-manual/manual$ ls
bulbasaur          deepin-cloud-print              deepin-movie                   deepin-system-monitor
dde                deepin-cloud-scan               deepin-music                   deepin-terminal
dde-file-manager   deepin-deb-installer            deepin-presentation-assistant  deepin-voice-recorder
deepin-appstore    deepin-editor                   deepin-remote-assistance       youdao-dict
deepin-boot-maker  deepin-font-installer           deepin-repair-tools
deepin-calculator  deepin-graphics-driver-manager  deepin-screen-recorder
deepin-clone       deepin-image-viewer             deepin-screenshot
pikachu@pikachu-PC:/usr/share/deepin-manual/manual$ 

```

/usr/share/dman
```shelll
pikachu@pikachu-PC:/usr/share/dman$ ls
deepin-cloud-scan
pikachu@pikachu-PC:/usr/share/dman$ 

```
