### PR TITLE
fix: sw架构帮助手册无法搜索

### DIFF
--- a/src/app/dman_helper.cpp
+++ b/src/app/dman_helper.cpp
@@ -40,6 +40,7 @@ int main(int argc, char **argv)
 
     qDebug() << Dtk::Core::DLogManager::getlogFilePath();
 
+#ifndef __sw_64__
     QOpenGLContext ctx;
     QSurfaceFormat fmt;
     fmt.setRenderableType(QSurfaceFormat::OpenGL);
@@ -51,6 +52,7 @@ int main(int argc, char **argv)
     fmt.setDefaultFormat(fmt);
     fmt.setProfile(QSurfaceFormat::CoreProfile);
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu");
+#endif
 
     Dtk::Core::DLogManager::registerFileAppender();
     Dtk::Core::DLogManager::registerConsoleAppender();


### PR DESCRIPTION
修复1050wayland模式无法搜索时添加了相关配置，可能与sw架构不适配

Log: sw架构帮助手册无法搜索

Bug: https://pms.uniontech.com/bug-view-117079.html