### PR TITLE
fix: 在终端输入“dman”启动应用，任务栏图标显示错误

### DIFF
--- a/src/app/dman.cpp
+++ b/src/app/dman.cpp
@@ -81,6 +81,7 @@ int main(int argc, char **argv)
     app.setOrganizationDomain("deepin.org");
     app.setApplicationVersion(VERSION);
     app.setApplicationName(kAppName);
+    app.setDesktopFileName("deepin-manual.desktop");
     app.loadTranslator();
     app.setApplicationDisplayName(QObject::tr("Manual"));
     app.setApplicationDescription(QObject::tr(

--- a/src/dbus/com.deepin.Manual.Open.service
+++ b/src/dbus/com.deepin.Manual.Open.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.Manual.Open
-Exec=/usr/bin/busctl --user call -- com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager LaunchApp suas /usr/share/applications/deepin-manual.desktop 0 1 --dbus
+Exec=/usr/bin/dman --dbus


### PR DESCRIPTION
Description: qtwayland中设置的appid为：org.deepin.dman，导致无法找到对应的desktop,所以启动图标 错误，程序中设置desktop为deepin-manual.desktop。更改dbus启动方式，可以直接用dman启动

Log: 在终端输入“dman”启动应用，任务栏图标显示错误

Bug: https://pms.uniontech.com/bug-view-142917.html