### PR TITLE
fix: 数据库中已有数据不能及时同步其他应用的md内容更新

### DIFF
--- a/src/controller/search_db.cpp
+++ b/src/controller/search_db.cpp
@@ -810,3 +810,25 @@ void SearchDb::getAllApp()
 {
     strlistApp = Utils::getSystemManualList();
 }
+
+void SearchDb::updateDb()
+{
+    //删除本地数据库
+    QString dbdir = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.local/share/deepin/deepin-manual/search.db" ;
+    QDir dir(dbdir);
+    if (!dir.exists()) {
+        qCritical() << __FUNCTION__ << "db path not exist!" << dbdir;
+    }
+
+    dir.remove(dbdir);
+    //重新加载数据库，创建新表
+    createTable();
+
+}
+
+void SearchDb::createTable()
+{
+    initDb();
+    initSearchTable();
+    initTimeTable();
+}

--- a/src/controller/search_db.h
+++ b/src/controller/search_db.h
@@ -60,6 +60,10 @@ public slots:
     QMap<QString, QString> selectAllFileTime();
 
     void getAllApp();
+    //更新数据库
+    void updateDb();
+    //创建数据库和相关表
+    void createTable();
 
 private:
     void initConnections();

--- a/src/controller/search_manager.cpp
+++ b/src/controller/search_manager.cpp
@@ -33,6 +33,7 @@ void SearchManager::initSearchManager()
     connect(db_, &SearchDb::searchContentResult, this, &SearchManager::searchContentResult);
     connect(db_, &SearchDb::searchContentMismatch, this, &SearchManager::searchContentMismatch);
     connect(this, &SearchManager::updateModule, db_, &SearchDb::updateModule);
+    connect(this, &SearchManager::updateDb, db_, &SearchDb::updateDb, Qt::BlockingQueuedConnection);
     connect(db_thread_, &QThread::destroyed, db_, &QObject::deleteLater);
 
     //初始化创建数据库SearchDb::initDb

--- a/src/controller/search_manager.h
+++ b/src/controller/search_manager.h
@@ -35,6 +35,8 @@ signals:
     void searchContentMismatch(const QString &keyword);
     void updateModule();
 
+    void updateDb();
+
 private:
     void initSearchManager();
 

--- a/src/controller/window_manager.h
+++ b/src/controller/window_manager.h
@@ -27,6 +27,8 @@ private:
     void activeOrInitWindow();
     void SendMsg(const QString &msg);
     void setWindow(WebWindow *window);
+    void updateDb();
+    void restartDmanHelper();
 
     QString curr_app_name_;
     QString curr_keyword_;

--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -705,6 +705,12 @@ void WebWindow::saveWindowSize()
     setting->endGroup();
 }
 
+void WebWindow::updateDb()
+{
+    //更新数据库
+    emit search_manager_->updateDb();
+}
+
 /**
  * @brief WebWindow::initShortcuts 设置窗口支持的快捷键
  */

--- a/src/view/web_window.h
+++ b/src/view/web_window.h
@@ -51,6 +51,7 @@ public:
     void openjsPage(const QString &app_name, const QString &title_name);
     void setAppProperty(const QString &appName, const QString &titleName, const QString &keyword);
     void saveWindowSize();
+    void updateDb();
 
     Dtk::Widget::DButtonBoxButton *m_backButton;
     Dtk::Widget::DButtonBoxButton *m_forwardButton;


### PR DESCRIPTION
Description: 在关闭帮助手册的时候，删除数据库并新建，重新通过dmanHelper加载数据

Log: 数据库中已有数据不能及时同步其他应用的md内容更新

Bug: https://pms.uniontech.com/bug-view-160195.html