### PR TITLE
chore: 去掉玲珑构建相关配置

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,15 +7,6 @@ project(deepin-manual C CXX)
 set(CMAKE_INSTALL_PREFIX /usr)
 add_definitions(-DDMAN_MANUAL_DIR="${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets")
 
-#web_dist玲珑环境需要更改目录
-if(DEFINED ENV{PREFIX})
-   set(CMAKE_INSTALL_PREFIX $ENV{PREFIX})
-   add_definitions(-DLINGLONGENV=1)
-else()
-   add_definitions(-DLINGLONGENV=0)
-   set(CMAKE_INSTALL_PREFIX /usr)
-endif()
-
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   add_definitions(-DDMAN_SEARCH_DB="${CMAKE_SOURCE_DIR}/manual-assets")
   add_definitions(-DDMAN_WEB_DIR="${CMAKE_CURRENT_SOURCE_DIR}/web_dist")
@@ -24,12 +15,6 @@ else()
   add_definitions(-DDMAN_SEARCH_DB="${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets")
   add_definitions(-DDMAN_WEB_DIR="${CMAKE_INSTALL_PREFIX}/share/deepin-manual/web_dist")
 endif ()
-#qwebengine玲珑路径
-add_definitions(-DDMAN_QWEBENGINE_DIR="${CMAKE_INSTALL_PREFIX}/lib")
-#webengine资源玲珑路径
-add_definitions(-DDMAN_WEBENGINERES_DIR="${CMAKE_INSTALL_PREFIX}/share/qt5/resources")
-#webengine翻译玲珑路径
-add_definitions(-DDMAN_WEBENGINETS_DIR="${CMAKE_INSTALL_PREFIX}/share/qt5/translations")
 
 #禁止Debug日志输出
 #add_definitions(-DQT_NO_DEBUG_OUTPUT)

--- a/src/app/dman.cpp
+++ b/src/app/dman.cpp
@@ -34,30 +34,28 @@ int main(int argc, char **argv)
     //禁用GPU
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu");
 
+#ifdef LINGLONG_BUILD
     //玲珑环境添加WebEngine
-    if (Utils::judgeLingLong()) {
-        QString webEngineProcessPath = DMAN_QWEBENGINE_DIR"" + QLibraryInfo::location(QLibraryInfo::LibrariesPath).mid(
-                                           QLibraryInfo::location(QLibraryInfo::LibrariesPath).lastIndexOf("/")) + QString("/qt5/libexec/QtWebEngineProcess");
-        QFile file(webEngineProcessPath);
-        if (file.exists())
-            qputenv("QTWEBENGINEPROCESS_PATH", webEngineProcessPath.toLocal8Bit());
-        else
-            qWarning() << "qputenv QTWEBENGINEPROCESS_PATH fail";
+    QString webEngineProcessPath = DMAN_QWEBENGINE_DIR"" + QLibraryInfo::location(QLibraryInfo::LibrariesPath).mid(
+                QLibraryInfo::location(QLibraryInfo::LibrariesPath).lastIndexOf("/")) + QString("/qt5/libexec/QtWebEngineProcess");
+    QFile file(webEngineProcessPath);
+    if (file.exists())
+        qputenv("QTWEBENGINEPROCESS_PATH", webEngineProcessPath.toLocal8Bit());
+    else
+        qWarning() << "qputenv QTWEBENGINEPROCESS_PATH fail";
 
-        QFile fileTs(DMAN_WEBENGINERES_DIR);
-        QFile fileRes(DMAN_WEBENGINETS_DIR);
-        if (fileTs.exists() && fileRes.exists())
-            qputenv("QTWEBENGINERESOURCE_PATH", (DMAN_WEBENGINETS_DIR":" + QString(DMAN_WEBENGINERES_DIR)).toStdString().c_str());
-        else
-            qWarning() << "qputenv QTWEBENGINERESOURCE_PATH fail";
+    QFile fileTs(DMAN_WEBENGINERES_DIR);
+    QFile fileRes(DMAN_WEBENGINETS_DIR);
+    if (fileTs.exists() && fileRes.exists())
+        qputenv("QTWEBENGINERESOURCE_PATH", (DMAN_WEBENGINETS_DIR":" + QString(DMAN_WEBENGINERES_DIR)).toStdString().c_str());
+    else
+        qWarning() << "qputenv QTWEBENGINERESOURCE_PATH fail";
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
+#else
+    if (!Utils::judgeWayLand()) {
         qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
     }
-    else {
-        //非玲珑环境waland下不设置
-        if (!Utils::judgeWayLand()) {
-            qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
-        }
-    }
+#endif
 
     //所有进程类型禁用沙箱..此配置开启禁用gpu后无效
 //    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--no-sandbox");

--- a/src/app/dman_helper.cpp
+++ b/src/app/dman_helper.cpp
@@ -25,31 +25,30 @@ int main(int argc, char **argv)
     //禁用GPU
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu");
 //    qputenv("QTWEBENGINE_REMOTE_DEBUGGING", "7777");
+
+#ifdef LINGLONG_BUILD
     //玲珑环境添加WebEngine
-    if (Utils::judgeLingLong()) {
-        QString webEngineProcessPath = DMAN_QWEBENGINE_DIR"" + QLibraryInfo::location(QLibraryInfo::LibrariesPath).mid(
-                                           QLibraryInfo::location(QLibraryInfo::LibrariesPath).lastIndexOf("/")) + QString("/qt5/libexec/QtWebEngineProcess");
-        QFile file(webEngineProcessPath);
-        if (file.exists())
-            qputenv("QTWEBENGINEPROCESS_PATH", webEngineProcessPath.toLocal8Bit());
-        else
-            qWarning() << "qputenv QTWEBENGINEPROCESS_PATH fail";
+    QString webEngineProcessPath = DMAN_QWEBENGINE_DIR"" + QLibraryInfo::location(QLibraryInfo::LibrariesPath).mid(
+                QLibraryInfo::location(QLibraryInfo::LibrariesPath).lastIndexOf("/")) + QString("/qt5/libexec/QtWebEngineProcess");
+    QFile file(webEngineProcessPath);
+    if (file.exists())
+        qputenv("QTWEBENGINEPROCESS_PATH", webEngineProcessPath.toLocal8Bit());
+    else
+        qWarning() << "qputenv QTWEBENGINEPROCESS_PATH fail";
 
-        QFile fileTs(DMAN_WEBENGINERES_DIR);
-        QFile fileRes(DMAN_WEBENGINETS_DIR);
-        if (fileTs.exists() && fileRes.exists())
-            qputenv("QTWEBENGINERESOURCE_PATH", (DMAN_WEBENGINETS_DIR":" + QString(DMAN_WEBENGINERES_DIR)).toStdString().c_str());
-        else
-            qWarning() << "qputenv QTWEBENGINERESOURCE_PATH fail";
+    QFile fileTs(DMAN_WEBENGINERES_DIR);
+    QFile fileRes(DMAN_WEBENGINETS_DIR);
+    if (fileTs.exists() && fileRes.exists())
+        qputenv("QTWEBENGINERESOURCE_PATH", (DMAN_WEBENGINETS_DIR":" + QString(DMAN_WEBENGINERES_DIR)).toStdString().c_str());
+    else
+        qWarning() << "qputenv QTWEBENGINERESOURCE_PATH fail";
 
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
+#else
+    if (!Utils::judgeWayLand()) {
         qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
     }
-    else {
-        //非玲珑环境waland下不设置
-        if (!Utils::judgeWayLand()) {
-            qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
-        }
-    }
+#endif
 
     ManualSearchProxy search_obj;
     ManualSearchAdapter adapter(&search_obj);

--- a/src/base/utils.cpp
+++ b/src/base/utils.cpp
@@ -235,32 +235,20 @@ bool Utils::judgeWayLand()
     return false;
 }
 
-bool Utils::judgeLingLong()
-{
-#ifdef LINGLONGENV
-    if (LINGLONGENV)
-        return true;
-    else
-        return false;
-#else
-    return false;
-#endif
-}
-
 QStringList Utils::getMdsourcePath()
 {
     QStringList sourcePath;
-    if (judgeLingLong()) {
-        QStringList pathlist = getEnvsourcePath();
-        for (int i = 0; i < pathlist.size(); ++i) {
-            if (pathlist[i].contains("persistent") || pathlist[i].contains("usr/share")) {
-                sourcePath.push_back(pathlist[i] + "/deepin-manual/manual-assets");
-                qDebug() << " all MD source path : " << sourcePath.last();
-            }
+#ifdef LINGLONG_BUILD
+    QStringList pathlist = getEnvsourcePath();
+    for (int i = 0; i < pathlist.size(); ++i) {
+        if (pathlist[i].contains("persistent") || pathlist[i].contains("usr/share")) {
+            sourcePath.push_back(pathlist[i] + "/deepin-manual/manual-assets");
+            qDebug() << " all MD source path : " << sourcePath.last();
         }
-    } else {
-        sourcePath.push_back(DMAN_MANUAL_DIR);
     }
+#else
+    sourcePath.push_back(DMAN_MANUAL_DIR);
+#endif
     return sourcePath;
 }
 

--- a/src/base/utils.h
+++ b/src/base/utils.h
@@ -50,8 +50,6 @@ public:
     static bool judgeLoongson();
     //判断是否Wayland
     static bool judgeWayLand();
-    //判断是否为玲珑平台
-    static bool judgeLingLong();
     //获取md文件路径
     static QStringList getMdsourcePath();
     //获取环境变量


### PR DESCRIPTION
   为保证在其他平台正常构建，取消JudgeLinglong接口判断，在下一笔提交中使用patch补丁进行玲珑构建条件编译

Log: 去掉玲珑构建相关配置