### PR TITLE
fix: 修复pangw架构下，多次重启帮助手册，有概率打开延迟15秒以上的问题

### DIFF
--- a/src/controller/config_manager.cpp
+++ b/src/controller/config_manager.cpp
@@ -6,6 +6,7 @@
 
 #include <QDir>
 #include <QStandardPaths>
+#include <QtDebug>
 
 ConfigManager *ConfigManager::_pInstance = nullptr;
 
@@ -13,6 +14,11 @@ ConfigManager::ConfigManager(QObject *parent)
     : QObject(parent)
 {
     m_winInfoConfig = new QSettings(getWinInfoConfigPath(), QSettings::IniFormat, this);
+}
+
+ConfigManager::~ConfigManager()
+{
+    qDebug() << "~configmanager....";
 }
 
 
@@ -28,6 +34,14 @@ ConfigManager *ConfigManager::getInstance()
         _pInstance =  new ConfigManager();
     }
     return _pInstance;
+}
+
+void ConfigManager::releaseInstance()
+{
+    if (_pInstance)
+        delete _pInstance;
+
+    _pInstance = nullptr;
 }
 
 /**

--- a/src/controller/config_manager.h
+++ b/src/controller/config_manager.h
@@ -13,11 +13,14 @@ class ConfigManager : public QObject
     Q_OBJECT
 public:
     static ConfigManager *getInstance();
+    static void releaseInstance();
     QString getWinInfoConfigPath();
     QSettings *getSettings();
 
 private:
     explicit ConfigManager(QObject *parent = nullptr);
+    ~ConfigManager();
+
     static ConfigManager *_pInstance;
     QSettings *m_winInfoConfig = nullptr;
 };

--- a/src/controller/window_manager.cpp
+++ b/src/controller/window_manager.cpp
@@ -34,6 +34,7 @@ WindowManager::~WindowManager()
     SendMsg("closeDmanHelper");
     updateDb();
     restartDmanHelper();
+    ConfigManager::releaseInstance();
     delete window;
 }
 

--- a/src/view/manual_proxy.cpp
+++ b/src/view/manual_proxy.cpp
@@ -77,7 +77,6 @@ void ManualProxy::setApplicationState(const QString &appName)
         qDebug() << setting->fileName() << ": " << strApp << " not find";
     }
     setting->endGroup();
-    setting->sync();
 }
 
 /**
@@ -347,7 +346,6 @@ void ManualProxy::saveAppList(const QStringList &list)
     }
     QStringList l = setting->allKeys();
     setting->endGroup();
-    setting->sync();
     qDebug() << "app config  allKeys count : " << l.size();
 }
 

--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -117,6 +117,8 @@ WebWindow::~WebWindow()
         search_edit_->deleteLater();
         search_edit_ = nullptr;
     }
+
+    qDebug() << "WebWindow::~WebWindow() done.";
 }
 
 /**


### PR DESCRIPTION
    程序会卡在QSettings::sync()接口，查阅资料，该接口不必显式调用，QSettings对象被析构时，会自动调用sync
接口，因此去掉所有显式调用sync接口地方，仅析构QSettings对象即可。

Log: 修复pangw架构下，多次重启帮助手册，有概率打开延迟15秒以上的问题

Bug: https://pms.uniontech.com/bug-view-185869.html