### PR TITLE
fix: 修复应用图标显示撕裂图的问题

### DIFF
--- a/src/base/utils.cpp
+++ b/src/base/utils.cpp
@@ -261,6 +261,21 @@ QStringList Utils::getEnvsourcePath()
     return pathlist;
 }
 
+QString Utils::getDesktopFilePath(const QString &desktopname)
+{
+    // 遍历XDG_DATA_DIRS中的路径，找寻指定desktop文件
+    QStringList pathList = getEnvsourcePath();
+    foreach (auto path, pathList) {
+        QString filepath = path + QString("/applications/%1.desktop").arg(desktopname);
+        QFile file(filepath);
+        if (file.exists()) {
+            return filepath;
+        }
+    }
+
+    return "";
+}
+
 /**
  * @brief Utils::getSystemManualList
  * @return　返回系统中存在帮助手册的应用列表

--- a/src/base/utils.h
+++ b/src/base/utils.h
@@ -54,6 +54,8 @@ public:
     static QStringList getMdsourcePath();
     //获取环境变量
     static QStringList getEnvsourcePath();
+    //获取desktop文件路径
+    static QString getDesktopFilePath(const QString &desktopname);
 };
 
 class ExApplicationHelper : public DGuiApplicationHelper

--- a/src/view/manual_proxy.cpp
+++ b/src/view/manual_proxy.cpp
@@ -244,6 +244,7 @@ QString ManualProxy::translateTitle(const QString &titleUS)
 //根据应用desktop文件解析图标名称并获取图标路径
 QString ManualProxy::getAppIconPath(const QString &desktopname)
 {
+    qDebug() << "getAppIconPath: desktopname:" << desktopname;
     //首次获取默认图标主题，如果获取失败默认bloom
     if (strIconTheme.isEmpty()) {
         QFile file("/usr/share/glib-2.0/schemas/com.deepin.dde.appearance.gschema.xml");
@@ -257,13 +258,15 @@ QString ManualProxy::getAppIconPath(const QString &desktopname)
         }
     }
 
-    QString filepath = QString("/usr/share/applications/%1.desktop").arg(desktopname);
+    QString filepath = Utils::getDesktopFilePath(desktopname);
     QFile file(filepath);
     QString strIcon = desktopname;
     if (file.exists()) {
         Dtk::Core::DDesktopEntry entry(filepath);
         strIcon = entry.stringValue("Icon");
         qDebug() << strIcon;
+    } else {
+        qDebug() << QString("filepath:%1 not exit.. desktopname:%2").arg(filepath).arg(desktopname);
     }
 
     QString strIconPath;


### PR DESCRIPTION
  玲珑环境下资源文件路径有变更，查询desktop文件，需要遍历XDG_DATA_DIRS中的路径

Log: 修复应用图标显示撕裂图的问题

Bug: https://pms.uniontech.com/bug-view-184047.html