### PR TITLE
fix: 修复帮助手册打开图片，锁屏/解锁后，帮助手册无法操作的问题

### DIFF
--- a/src/view/web_window.h
+++ b/src/view/web_window.h
@@ -120,6 +120,8 @@ private slots:
     void onSetKeyword(const QString &keyword);
     void onManualSearchByKeyword(const QString &keyword);
     void onAppearanceChanged(QString, QMap<QString, QVariant>, QStringList);
+    // 是否锁屏
+    void onTimeoutLock(const QString &, QVariantMap, QStringList);
 };
 
 #endif // DEEPIN_MANUAL_VIEW_WEB_WINDOW_H


### PR DESCRIPTION
  看图界面为模态界面，锁屏或息屏时需要显式隐藏看图界面，才能将鼠标事件传递给主线程

Log: 修复帮助手册打开图片，锁屏/解锁后，帮助手册无法操作的问题

Bug: https://pms.uniontech.com/bug-view-189621.html