### PR TITLE
fix: 修复系统启动后dmanHelper成为常驻进程的问题

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,6 +289,8 @@ add_executable(dmanHelper
                 dbus/manual_search_adapter.h
                 dbus/manual_search_proxy.cpp
                 dbus/manual_search_proxy.h
+                dbus/dmanwatcher.cpp
+                dbus/dmanwatcher.h
                 base/command.cpp
                 base/command.h
                 controller/helpermanager.cpp

--- a/src/app/dman_helper.cpp
+++ b/src/app/dman_helper.cpp
@@ -6,6 +6,7 @@
 #include "dbus/dbus_consts.h"
 #include "dbus/manual_search_adapter.h"
 #include "dbus/manual_search_proxy.h"
+#include "dbus/dmanwatcher.h"
 
 #include <DLog>
 
@@ -23,6 +24,8 @@ int main(int argc, char **argv)
 
 //    qputenv("QTWEBENGINE_REMOTE_DEBUGGING", "7777");
 
+    // 后端服务dmanHelper自检，若前端dman应用不存在，则后端dmanHelper退出
+    DManWatcher watcher;
     ManualSearchProxy search_obj;
     ManualSearchAdapter adapter(&search_obj);
 

--- a/src/dbus/dmanwatcher.cpp
+++ b/src/dbus/dmanwatcher.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dmanwatcher.h"
+
+#include <QProcess>
+#include <QCoreApplication>
+#include <QDebug>
+
+DManWatcher::DManWatcher():m_Timer(new QTimer (this))
+{
+
+    connect(m_Timer,&QTimer::timeout,this,&DManWatcher::onTimeOut);
+    m_Timer->start(5000);
+}
+
+/**
+ * @brief 定时监控客户端
+ */
+void DManWatcher::onTimeOut()
+{
+    QString cmd, outPut;
+    //判断dman客户端是否存在，如果不存在退出服务。
+    cmd = QString("ps aux | grep -w dman$");
+    outPut= executCmd(cmd);
+    int ret = outPut.length();
+    if (!ret)
+        QCoreApplication::exit(0);
+}
+
+/**
+ * @brief 执行外部命令
+ * @param strCmd:外部命令字符串
+ */
+QString DManWatcher::executCmd(const QString &strCmd)
+{
+     QProcess proc;
+     proc.start("bash", QStringList() << "-c" << strCmd);
+     proc.waitForFinished(-1);
+     return  proc.readAllStandardOutput();
+}

--- a/src/dbus/dmanwatcher.h
+++ b/src/dbus/dmanwatcher.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DMANWATCHER_H
+#define DMANWATCHER_H
+
+#include <QObject>
+#include <QTimer>
+
+/**
+ * @class DManWatcher
+ * @brief 监控客户端类
+ */
+class DManWatcher :public QObject
+{
+    Q_OBJECT
+public:
+    explicit DManWatcher();
+
+public Q_SLOTS:
+    void onTimeOut();
+private:
+    QString executCmd(const QString &strCmd);
+private:
+    QTimer *m_Timer=nullptr;
+};
+
+#endif // DMANWATCHER_H

--- a/src/view/theme_proxy.cpp
+++ b/src/view/theme_proxy.cpp
@@ -5,6 +5,8 @@
 #include "view/theme_proxy.h"
 #include <DApplicationHelper>
 
+DGUI_USE_NAMESPACE
+
 ThemeProxy::ThemeProxy(QObject *parent)
     : QObject(parent)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ FILE (GLOB allTestSource
 FILE (GLOB dmanCppFiles
     ../src/base/consts.cpp
     ../src/base/utils.cpp
+    ../src/base/eventlogutils.cpp
     ../src/controller/*.cpp
     ../src/dbus/*.cpp
     ../src/dbus/dbusvariant/*.cpp
@@ -132,6 +133,7 @@ FILE (GLOB dmanCppFiles
 
 FILE (GLOB dmanHeaderFiles
     ../src/base/consts.h
+    ../src/base/eventlogutils.h
     ../src/base/utils.h
     ../src/controller/*.h
     ../src/dbus/*.h


### PR DESCRIPTION
  后端内置定时器，每5秒检查前端dman是否存在，若不存在，则后端dmanHelper退出

Log: 修复系统启动后dmanHelper成为常驻进程的问题