### PR TITLE
fix: 双屏扩展模式下，帮助手册在主屏最大化再还原，窗口会直接显示到副屏

### DIFF
--- a/src/controller/window_manager.cpp
+++ b/src/controller/window_manager.cpp
@@ -176,7 +176,6 @@ void WindowManager::setWindow(WebWindow *window)
     //设置window窗口属性
     window->resize(saveWidth, saveHeight);
     window->setMinimumSize(kWinMinWidth, kWinMinHeight);
-    window->move((QApplication::desktop()->width() - saveWidth) / 2, (QApplication::desktop()->height() - saveHeight) / 2);
 }
 
 void WindowManager::updateDb()

--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -342,12 +342,6 @@ void WebWindow::resizeEvent(QResizeEvent *event)
             completion_window_->move(local_point);
         }
     }
-    // 多屏下仅采用单个屏幕处理， 使用主屏的宽度计算
-    QScreen *screen = QGuiApplication::primaryScreen();
-    if (QGuiApplication::screens().size() > 1 && screen) {
-        move((screen->size().width() - size().width()) / 2, (screen->size().height() - size().height()) / 2);
-
-    }
 
     if (web_view_) {
         slot_ThemeChanged();


### PR DESCRIPTION
修复双屏扩展模式下，帮助手册在主屏最大化再还原，窗口会直接显示到副屏

Log: 修复双屏扩展模式下，帮助手册在主屏最大化再还原，窗口会直接显示到副屏

Bug: https://pms.uniontech.com/bug-view-244417.html