### PR TITLE
fix: 老版本浏览器无法打开视频链接

### DIFF
--- a/src/view/manual_proxy.cpp
+++ b/src/view/manual_proxy.cpp
@@ -10,6 +10,7 @@
 #include <DDesktopEntry>
 
 #include <QtGui/private/qiconloader_p.h>
+#include <QDesktopServices>
 
 ManualProxy::ManualProxy(QObject *parent)
     : QObject(parent)
@@ -409,9 +410,7 @@ void ManualProxy::openVideo(QString url)
     if(url.isEmpty()) {
         url = videoUrl;
     }
-    QProcess process;
-    process.startDetached("browser", QStringList(url));
-    process.waitForFinished();
+    QDesktopServices::openUrl(url);
 }
 
 /**


### PR DESCRIPTION
修复老版本浏览器无法打开视频指南链接问题

Log: 修复老版本浏览器无法打开视频链接问题

Bug: https://pms.uniontech.com/bug-view-249541.html