### PR TITLE
fix: fail to view application manual

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.3.1
+  version: 6.5.4.1
   kind: app
   description: |
     manual for deepin os.
@@ -27,7 +27,6 @@ build: |
   find ${PREFIX} -name "Qt5WebChannelConfig.cmake" -exec sed -i "s|NO_DEFAULT_PATH||g" {} +
 
   #修改服务使用玲珑启动
-  sed -i "s|Exec=/usr/bin/dmanHelper|Exec=/usr/bin/ll-cli run org.deepin.manual --exec \"dmanHelper\"|g" $PWD/src/dbus/com.deepin.Manual.Search.service
   sed -i "s|ExecStart=/usr/bin/dman --dbus|ExecStart=/usr/bin/ll-cli run org.deepin.manual --exec \"dman --dbus\"|g" $PWD/misc/deepin-manual.service
 
   # 获取版本号

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-manual (6.5.4) unstable; urgency=medium
+
+  * fix: fail to view application manual.
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 24 Oct 2024 13:59:02 +0800
+
 deepin-manual (6.5.3) unstable; urgency=medium
 
   * chore: linglong package slimming.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.3.1
+  version: 6.5.4.1
   kind: app
   description: |
     manual for deepin os.
@@ -27,7 +27,6 @@ build: |
   find ${PREFIX} -name "Qt5WebChannelConfig.cmake" -exec sed -i "s|NO_DEFAULT_PATH||g" {} +
 
   #修改服务使用玲珑启动
-  sed -i "s|Exec=/usr/bin/dmanHelper|Exec=/usr/bin/ll-cli run org.deepin.manual --exec \"dmanHelper\"|g" $PWD/src/dbus/com.deepin.Manual.Search.service
   sed -i "s|ExecStart=/usr/bin/dman --dbus|ExecStart=/usr/bin/ll-cli run org.deepin.manual --exec \"dman --dbus\"|g" $PWD/misc/deepin-manual.service
 
   # 获取版本号

--- a/src/app/dman.cpp
+++ b/src/app/dman.cpp
@@ -79,6 +79,12 @@ int main(int argc, char **argv)
         format.setDefaultFormat(format);
     }
 
+    // 增加路径以搜索主机应用和玲珑应用中的帮助手册
+    if (qEnvironmentVariableIsSet("LINGLONG_APPID")) {
+        QByteArray paths = qgetenv("XDG_DATA_DIRS");
+        paths.append(":/run/host/rootfs/usr/share:/run/host/rootfs/var/lib/linglong/entries/share");
+        qputenv("XDG_DATA_DIRS", paths);
+    }
 
     Dtk::Widget::DApplication app(argc, argv);
     if (!DPlatformWindowHandle::pluginVersion().isEmpty()) {


### PR DESCRIPTION
With the value of XDG_DATA_DIRS before the fix, we can only view the help information of deepin-manual itself. In order to view the help manuals in the host application and linglong application, let's add the relevant paths.

Log: Adapt linglong