### PR TITLE
fix: fix fail to launch linglong app via dbus

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.6.1
+  version: 6.5.7.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-manual (6.5.7) unstable; urgency=medium
+
+  * fix fail to launch linglong app via dbus.
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 18 Nov 2024 19:42:16 +0800
+
 deepin-manual (6.5.6) unstable; urgency=medium
 
   * adapt compact mode 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.6.1
+  version: 6.5.7.1
   kind: app
   description: |
     manual for deepin os.

--- a/src/dbus/CMakeLists.txt
+++ b/src/dbus/CMakeLists.txt
@@ -3,7 +3,10 @@ if(DEFINED ENV{PREFIX})
 else()
    set(CMAKE_INSTALL_PREFIX /usr)
 endif()
+
+configure_file(com.deepin.Manual.Search.service.in com.deepin.Manual.Search.service @ONLY)
+
 install(FILES
         com.deepin.Manual.Open.service
-        com.deepin.Manual.Search.service
+        ${CMAKE_CURRENT_BINARY_DIR}/com.deepin.Manual.Search.service
         DESTINATION share/dbus-1/services/)

--- a/src/dbus/com.deepin.Manual.Search.service.in
+++ b/src/dbus/com.deepin.Manual.Search.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.Manual.Search
-Exec=/usr/bin/dmanHelper
+Exec=@CMAKE_INSTALL_PREFIX@/bin/dmanHelper


### PR DESCRIPTION
Because the DBUS .Service file uses a fixed executable file path, it has caused the failure to start the app in the linglong environment. Let us dynamically generate this file.

Log: fix fail to launch linglong app via dbus
Bug: https://pms.uniontech.com/bug-view-282545.html
Bug: https://pms.uniontech.com/bug-view-282353.html
Bug: https://pms.uniontech.com/bug-view-281637.html
Bug: https://pms.uniontech.com/bug-view-282113.html