### PR TITLE
chore: Bump version to 6.5.18 and update dependencies

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.17.1
+  version: 6.5.18.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-manual (6.5.18) unstable; urgency=medium
+
+  * Update version to 6.5.18
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 02 Apr 2025 15:09:51 +0800
+
 deepin-manual (6.5.17) unstable; urgency=medium
 
   * chore: v6.5.17 release.

--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,7 @@ Package:deepin-manual
 Architecture: any
 Depends: ${misc:Depends},
  ${shlibs:Depends},
+ libqt6webenginecore6-bin [!mipsel !mips64el] | libqt5core5a
 Recommends: qt5dxcb-plugin,uos-reporter, deepin-event-log
 Conflicts: dde-help
 Provides: dde-help

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.17.1
+  version: 6.5.18.1
   kind: app
   description: |
     manual for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.17.1
+  version: 6.5.18.1
   kind: app
   description: |
     manual for deepin os.


### PR DESCRIPTION
Updated the version of deepin-manual to 6.5.18 in all relevant files. Added a new dependency for libqt6webenginecore6-bin in the control file. Updated the changelog to reflect the new version.