### PR TITLE
fix: Disable chrome flag on mips architecture / bump version to 6.5.19

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-manual (6.5.19) unstable; urgency=medium
+
+  * chore: update translations.
+  * fix: Disable chrome flag on mips architecture
+
+ -- renbin <renbin@uniontech.com>  Thu, 10 Apr 2025 20:08:34 +0800
+
 deepin-manual (6.5.18) unstable; urgency=medium
 
   * Update version to 6.5.18

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     manual for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     manual for deepin os.

--- a/src/app/dman.cpp
+++ b/src/app/dman.cpp
@@ -32,6 +32,13 @@ int main(int argc, char **argv)
     //禁用GPU
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu");
 
+    qputenv("DTK_USE_SEMAPHORE_SINGLEINSTANCE", "1");
+#ifdef __mips__
+    bool enableChromeFlag = false;
+#else
+    bool enableChromeFlag = true;
+#endif
+
 #ifdef LINGLONG_BUILD
     //玲珑环境添加WebEngine
     QString webEngineProcessPath = DMAN_QWEBENGINE_DIR"" + QLibraryInfo::location(QLibraryInfo::LibrariesPath).mid(
@@ -48,9 +55,12 @@ int main(int argc, char **argv)
         qputenv("QTWEBENGINERESOURCE_PATH", (DMAN_WEBENGINETS_DIR":" + QString(DMAN_WEBENGINERES_DIR)).toStdString().c_str());
     else
         qWarning() << "qputenv QTWEBENGINERESOURCE_PATH fail";
-    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
+
+    if (enableChromeFlag) {
+        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
+    }
 #else
-    if (!Utils::judgeWayLand()) {
+    if (enableChromeFlag && !Utils::judgeWayLand()) {
         qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--single-process");
     }
 #endif


### PR DESCRIPTION
[fix: Disable chrome flag on mips architecture](https://github.com/linuxdeepin/deepin-manual/commit/7f22d3a75c1a213c1a9c9690f706e70bd045301c) 

As title.

Log: Disable chrome flag on mips architecture

[chore: Bump version to 6.5.19](https://github.com/linuxdeepin/deepin-manual/commit/dd8e46c5a070070c6907ff0c6514f0335769b0e9) 

Bump version to 6.5.19

Log: Bump version to 6.5.19