### PR TITLE
Suppress video guide for UOS Community edition

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-manual (6.5.22) unstable; urgency=medium
+
+  * Suppress video guide for UOS Community edition.
+  * Update version to 6.5.22
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 08 May 2025 17:48:24 +0800
+
 deepin-manual (6.5.21) unstable; urgency=medium
 
   * Using dbus interface instead of dtk sysinfo to get Os edition infomation.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     manual for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     manual for deepin os.

--- a/src/view/manual_proxy.cpp
+++ b/src/view/manual_proxy.cpp
@@ -331,7 +331,7 @@ QString ManualProxy::getLocalAppName(const QString &desktopname)
 QVariant ManualProxy::getVideoGuideInfo()
 {
     // 社区版不出现视频指南，返回空进行屏蔽
-    if(Utils::uosEditionType() == Dtk::Core::DSysInfo::UosEdition::UosCommunity)
+    if (Utils::uosEditionType() == Dtk::Core::DSysInfo::UosEdition::UosCommunity)
         return QVariantList();
 
     QFile file(kVideoConfigPath);


### PR DESCRIPTION
    fix: Suppress video guide for UOS Community edition
    
    - Added a check to return an empty QVariantList for the UOS Community edition to prevent displaying the video guide.
    
    bug：https://pms.uniontech.com/bug-view-310445.html