### PR TITLE
fix: Refactor uosEditionType checks in getSystemManualList function

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.22.1
+  version: 6.5.23.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-manual (6.5.23) UNRELEASED; urgency=medium
+
+  * Suppress quick-start for UOS Community edition.
+  * Update version to 6.5.23
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 09 May 2025 10:14:23 +0800
+
 deepin-manual (6.5.22) unstable; urgency=medium
 
   * Suppress video guide for UOS Community edition.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.22.1
+  version: 6.5.23.1
   kind: app
   description: |
     manual for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.22.1
+  version: 6.5.23.1
   kind: app
   description: |
     manual for deepin os.

--- a/src/base/utils.cpp
+++ b/src/base/utils.cpp
@@ -286,17 +286,18 @@ QStringList Utils::getSystemManualList()
 {
     QStringList app_list_;
     QStringList strMANUAL_DIR_list = Utils::getMdsourcePath();
+    Dtk::Core::DSysInfo::UosEdition type = Utils::uosEditionType();
     foreach (auto strMANUAL_DIR, strMANUAL_DIR_list) {
         const QStringList applicationList = QDir(QString("%1/application/").arg(strMANUAL_DIR)).entryList(QDir::Dirs|QDir::NoDotAndDotDot);
         const QStringList systemList = QDir(QString("%1/system/").arg(strMANUAL_DIR)).entryList(QDir::Dirs|QDir::NoDotAndDotDot);
         QString oldMdPath = strMANUAL_DIR;
         if (Dtk::Core::DSysInfo::UosServer == Dtk::Core::DSysInfo::uosType()) {
             oldMdPath += "/server";
-        } else if (Dtk::Core::DSysInfo::UosHome == Utils::uosEditionType()) {
+        } else if (Dtk::Core::DSysInfo::UosHome == type) {
             oldMdPath += "/personal";
-        } else if (Dtk::Core::DSysInfo::UosEducation == Utils::uosEditionType()) {
+        } else if (Dtk::Core::DSysInfo::UosEducation == type) {
             oldMdPath += "/education";
-        } else if (Dtk::Core::DSysInfo::UosCommunity == Utils::uosEditionType()) {
+        } else if (Dtk::Core::DSysInfo::UosCommunity == type) {
             oldMdPath += "/community";
         } else {
             oldMdPath += "/professional";
@@ -312,14 +313,13 @@ QStringList Utils::getSystemManualList()
                 app_list_.append("dde");
             }
         }
-
         // 非应用文档，直接添加
         if (systemList.contains(kLearnBasicOperations) || oldAppList.contains(kLearnBasicOperations)) {
-            if (app_list_.indexOf(kLearnBasicOperations) == -1)
+            if (Dtk::Core::DSysInfo::UosCommunity != type && app_list_.indexOf(kLearnBasicOperations) == -1)
                 app_list_.append(kLearnBasicOperations);
         }
         if (systemList.contains(kCommonApplicationLibraries) || oldAppList.contains(kCommonApplicationLibraries)) {
-            if (app_list_.indexOf(kCommonApplicationLibraries) == -1)
+            if (Dtk::Core::DSysInfo::UosCommunity != type && app_list_.indexOf(kCommonApplicationLibraries) == -1 )
                 app_list_.append(kCommonApplicationLibraries);
         }
         qDebug() << "exist app list: " << app_list_ << ", count:" << app_list_.size();


### PR DESCRIPTION
fix: Refactor uosEditionType checks in getSystemManualList function
    
    - Replaced multiple calls to Utils::uosEditionType() with a single call to improve performance and readability.
    - Added a condition to prevent adding certain applications to the list for UOS Community edition.
    - Enhanced debug output for better tracking of application list generation.
    
    bug: https://pms.uniontech.com/bug-view-310445.html