### PR TITLE
chore: Update version to 6.5.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-deepin-manual (6.5.23) UNRELEASED; urgency=medium
+deepin-manual (6.5.23) unstable; urgency=medium
 
   * Suppress quick-start for UOS Community edition.
   * Update version to 6.5.23


### PR DESCRIPTION
- Bump version to 6.5.23.
- Reflect changes in debian/changelog for release preparation.

log: Update version to 6.5.23