### PR TITLE
fix: Add support for UOS Military and UOS MilitaryS editions in OS bu…

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-manual (6.5.26) unstable; urgency=medium
+
+  * Update version to 6.5.26 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 23 May 2025 18:03:04 +0800
+
 deepin-manual (6.5.25) unstable; urgency=medium
 
   * Update version to 6.5.25 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     manual for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     manual for deepin os.

--- a/src/base/utils.cpp
+++ b/src/base/utils.cpp
@@ -495,6 +495,7 @@ Dtk::Core::DSysInfo::UosEdition Utils::parseOsBuildType(const QString & osBuild)
         case 3:
             return Dtk::Core::DSysInfo::UosEdition::UosCommunity;
         case 4:
+        case 9:
             return Dtk::Core::DSysInfo::UosEdition::UosMilitary;
         case 5:
             return Dtk::Core::DSysInfo::UosEdition::UosDeviceEdition;
@@ -513,6 +514,7 @@ Dtk::Core::DSysInfo::UosEdition Utils::parseOsBuildType(const QString & osBuild)
         case 3:
             return Dtk::Core::DSysInfo::UosEdition::UosEuler;
         case 4:
+        case 9:
             return Dtk::Core::DSysInfo::UosEdition::UosMilitaryS;
         case 5:
             return Dtk::Core::DSysInfo::UosEdition::UosDeviceEdition;


### PR DESCRIPTION
…ild type parser

- Updated the parseOsBuildType function to handle case 9 for both UOS Military and UOS MilitaryS editions.
- Ensured compatibility with additional OS build types.

bug: https://pms.uniontech.com/bug-view-316891.html