### PR TITLE
Fix: Page lags when scrolling in Help Manual

### DIFF
--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -723,7 +723,24 @@ void WebWindow::initWebView()
     web_view_ = new QWebEngineView;
     web_view_->setAttribute(Qt::WA_KeyCompression, true);
     web_view_->setAttribute(Qt::WA_InputMethodEnabled, true);
-
+#ifdef QT_DEBUG
+    // 创建开发者工具窗口并设置
+    devToolsView = new QWebEngineView();
+    devToolsView->setWindowTitle("Developer Tools - deepin-manual");
+    devToolsView->resize(1200, 800);
+    web_view_->page()->setDevToolsPage(devToolsView->page());
+    
+    // 添加快捷键F12打开开发者工具
+    QShortcut *devToolsShortcut = new QShortcut(QKeySequence::fromString("F12"), this);
+    connect(devToolsShortcut, &QShortcut::activated, [this]() {
+        if (devToolsView && devToolsView->isVisible()) {
+            devToolsView->hide();
+        } else if (devToolsView) {
+            devToolsView->show();
+            devToolsView->raise();
+        }
+    });
+#endif // QT_DEBUG
     // 添加web_view_页面到stackWidget
     m_CentralStackWidget->addWidget(web_view_);
 

--- a/src/view/web_window.h
+++ b/src/view/web_window.h
@@ -105,6 +105,7 @@ private:
     SettingsProxy *settings_proxy_ {nullptr};
     TitleBar *title_bar_ {nullptr};
     QWebEngineView *web_view_ {nullptr};
+    QWebEngineView *devToolsView {nullptr};
     QTimer search_timer_ {nullptr};
     Dtk::Widget::DButtonBox *buttonBox {nullptr};
     SearchEdit *search_edit_ {nullptr};


### PR DESCRIPTION
The frontend requires image paths for display. However, some icon paths cannot be found in the current theme's directory, necessitating an expanded search path, which slows down performance.

This change addresses the issue by converting icons to base64 for display.

Bug: https://pms.uniontech.com/bug-view-317869.html