### PR TITLE
Fix: Page lags when scrolling in Help Manual

### DIFF
--- a/src/view/manual_proxy.cpp
+++ b/src/view/manual_proxy.cpp
@@ -12,25 +12,9 @@
 
 #include <QIcon>
 #include <QDesktopServices>
-
-namespace {
-    // 迭代查找图标
-    QString findIconFile(const QString &iconName, const QString &directory) {
-        QDirIterator it(directory,
-                        QStringList() << "*.svg",
-                        QDir::Files,
-                        QDirIterator::Subdirectories);
-
-        while (it.hasNext()) {
-            it.next();
-            if (it.fileInfo().baseName() == iconName) {
-                return it.fileInfo().absoluteFilePath();
-            }
-        }
-
-        return QString();
-    }
-}
+#include <QDir>
+#include <QSettings>
+#include <QBuffer>
 
 ManualProxy::ManualProxy(QObject *parent)
     : QObject(parent)
@@ -289,49 +273,40 @@ QString ManualProxy::getAppIconPath(const QString &desktopname)
         Dtk::Core::DDesktopEntry entry(filepath);
         strIcon = entry.stringValue("Icon");
     } else {
-        qCWarning(app) << QString("filepath:%1 not exit.. desktopname:%2").arg(filepath).arg(desktopname);
+        qCWarning(app) << QString("filepath:%1 not exist.. desktopname:%2").arg(filepath).arg(desktopname);
     }
 
-    QString strIconPath;
+    qCDebug(app) << "Icon name:" << strIcon;
+
     if (QIcon::hasThemeIcon(strIcon)) {
         QIcon icon = QIcon::fromTheme(strIcon);
-        QStringList themePaths = icon.themeSearchPaths();
-        QString iconPath;
-
-        // 遍历主题路径，查找图标文件
-        for (const QString &themePath : themePaths) {
-            QStringList iconSizes = {"96", "64", "48", "36"};
-            for (const QString &size : iconSizes) {
-                QString path = QString("%1/%2/apps/%3/%4.svg").arg(themePath).arg(strIconTheme).arg(size).arg(strIcon);
-                if (QFile::exists(path)) {
-                    iconPath = path;
-                    break;
-                }
+        if (!icon.isNull()) {
+            // 强制目标尺寸为 96x96， 与前端的展示尺寸一致，避免转换成base64的时候超大无法正常显示
+            QSize targetSize(96, 96);
+            QPixmap pixmap = icon.pixmap(targetSize);
+            if (!pixmap.isNull()) {
+                QByteArray byteArray;
+                QBuffer buffer(&byteArray);
+                buffer.open(QIODevice::WriteOnly);
+                pixmap.save(&buffer, "PNG");
+                buffer.close(); 
+                
+                // 转换为base64
+                QString base64 = byteArray.toBase64();
+                QString dataUrl = QString("data:image/png;base64,%1").arg(base64);
+                return dataUrl;
+            } else {
+                qCWarning(app) << "Failed to get pixmap for" << strIcon;
             }
-
-            if (!iconPath.isEmpty()) {
-                break;
-            }
+        } else {
+            qCWarning(app) << "Icon is null for:" << strIcon;
         }
-
-        // 上面主题查找的方式没有的时候在图标路径遍历查找一下
-        if (iconPath.isEmpty())
-        {
-            for (const QString &themePath : themePaths) {
-
-                QString findPath = findIconFile(strIcon, themePath);
-                if (QFile::exists(findPath)) {
-                    iconPath = findPath;
-                    break;
-                }
-            }
-        }
-
-        if (!iconPath.isEmpty()) {
-            strIconPath = iconPath;
-        }
+    } else {
+        qCWarning(app) << "No theme icon found for:" << strIcon;
     }
-    return strIconPath;
+
+    qCWarning(app) << "Failed to get icon for:" << strIcon;
+    return "";
 }
 
 QString ManualProxy::getLocalAppName(const QString &desktopname)

--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -723,7 +723,24 @@ void WebWindow::initWebView()
     web_view_ = new QWebEngineView;
     web_view_->setAttribute(Qt::WA_KeyCompression, true);
     web_view_->setAttribute(Qt::WA_InputMethodEnabled, true);
-
+#ifdef QT_DEBUG
+    // 创建开发者工具窗口并设置
+    devToolsView = new QWebEngineView();
+    devToolsView->setWindowTitle("Developer Tools - deepin-manual");
+    devToolsView->resize(1200, 800);
+    web_view_->page()->setDevToolsPage(devToolsView->page());
+    
+    // 添加快捷键F12打开开发者工具
+    QShortcut *devToolsShortcut = new QShortcut(QKeySequence::fromString("F12"), this);
+    connect(devToolsShortcut, &QShortcut::activated, [this]() {
+        if (devToolsView && devToolsView->isVisible()) {
+            devToolsView->hide();
+        } else if (devToolsView) {
+            devToolsView->show();
+            devToolsView->raise();
+        }
+    });
+#endif // QT_DEBUG
     // 添加web_view_页面到stackWidget
     m_CentralStackWidget->addWidget(web_view_);
 

--- a/src/view/web_window.h
+++ b/src/view/web_window.h
@@ -105,6 +105,7 @@ private:
     SettingsProxy *settings_proxy_ {nullptr};
     TitleBar *title_bar_ {nullptr};
     QWebEngineView *web_view_ {nullptr};
+    QWebEngineView *devToolsView {nullptr};
     QTimer search_timer_ {nullptr};
     Dtk::Widget::DButtonBox *buttonBox {nullptr};
     SearchEdit *search_edit_ {nullptr};


### PR DESCRIPTION
The frontend requires image paths for display. However, some icon paths cannot be found in the current theme's directory, necessitating an expanded search path, which slows down performance.

This change addresses the issue by converting icons to base64 for display.

Bug: https://pms.uniontech.com/bug-view-317869.html