### PR TITLE
fix: Add destructor to helperManager for proper resource cleanup

### DIFF
--- a/src/controller/helpermanager.cpp
+++ b/src/controller/helpermanager.cpp
@@ -37,6 +37,15 @@ helperManager::helperManager(QObject *parent)
     qCDebug(app) << "helperManager initialized successfully";
 }
 
+helperManager::~helperManager()
+{
+    if (m_webView) {
+        qCDebug(app) << "Deleting WebEngineView";
+        delete m_webView;
+        m_webView = nullptr;
+    }
+}
+
 /**
  * @brief helperManager::initWeb 初始化web配置
  */

--- a/src/controller/helpermanager.h
+++ b/src/controller/helpermanager.h
@@ -20,6 +20,7 @@ class helperManager  : public QObject
     Q_OBJECT
 public:
     explicit helperManager(QObject *parent = nullptr);
+    virtual ~helperManager();
 
 private:
 


### PR DESCRIPTION
- Implemented a destructor in helperManager to ensure WebEngine resources are correctly released.
- Added nullification of m_webView to prevent potential memory leaks.

This change enhances resource management within the helperManager class.

bug： https://pms.uniontech.com/bug-view-324131.html