### PR TITLE
fix: Implement process timeout handling in SpawnCmd

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.39.1
+  version: 6.5.40.1
   kind: app
   description: |
     manual for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-manual (6.5.40) unstable; urgency=medium
+
+  * Fix the database may be incompletely created, resulting in no searches.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 25 Sep 2025 21:28:16 +0800
+
 deepin-manual (6.5.39) unstable; urgency=medium
 
   * chore: Update linglong base and runtime

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.39.1
+  version: 6.5.40.1
   kind: app
   description: |
     manual for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.39.1
+  version: 6.5.40.1
   kind: app
   description: |
     manual for deepin os.

--- a/src/base/command.cpp
+++ b/src/base/command.cpp
@@ -65,8 +65,14 @@ bool SpawnCmd(const QString &cmd, const QStringList &args)
     process.start();
     qCDebug(app) << "Process started, PID:" << process.processId();
 
-    // Wait for process to finish without timeout.
-    process.waitForFinished(-1);
+    // Wait for process to finish with default timeout.
+    bool finished = process.waitForFinished();
+    if (!finished) {
+        qCWarning(app) << "Command timed out, terminating process";
+        process.kill();
+        process.waitForFinished(500);
+        return false;
+    }
 
     qCDebug(app) << "Command output:" << process.readAllStandardOutput();
 
@@ -92,8 +98,14 @@ bool SpawnCmd(const QString &cmd, const QStringList &args,
     process.start();
     qCDebug(app) << "Process started, PID:" << process.processId();
 
-    // Wait for process to finish without timeout.
-    process.waitForFinished(-1);
+    // Wait for process to finish with default timeout.
+    bool finished = process.waitForFinished();
+    if (!finished) {
+        qCWarning(app) << "Command timed out, terminating process";
+        process.kill();
+        process.waitForFinished(500);
+        return false;
+    }
     output = process.readAllStandardOutput();
     err = process.readAllStandardError();
     if (!process.errorString().contains("Unknown")) {


### PR DESCRIPTION
- Updated SpawnCmd to wait for process completion with a default timeout. This change improves the robustness of command execution by preventing indefinite hangs.

Log: Fix the database may be incompletely created, resulting in no searches.