### PR TITLE
fix(view): fix scroll unresponsiveness after mouse click in web view

### DIFF
--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -522,8 +522,8 @@ bool WebWindow::eventFilter(QObject *watched, QEvent *event)
         qCDebug(app) << "eventFilter mouse release";
         QRect rect = hasWidgetRect(search_edit_);
         if (web_view_ && web_view_->selectedText().isEmpty() && !rect.contains(QCursor::pos())) {
-            qCDebug(app) << "set focus to web view";
-            this->setFocus();
+            qCDebug(app) << "set focus to web view to maintain scroll responsiveness";
+            web_view_->setFocus();
         }
     }
     if (event->type() == QEvent::KeyPress && qApp->activeWindow() == this) {


### PR DESCRIPTION
Keep focus on QWebEngineView after mouse release to maintain scroll responsiveness when user interacts with content area.

修复鼠标点击后滚动无响应的问题，保持焦点在 QWebEngineView 上
以维持滚轮事件的响应能力。

Log: 修复帮助手册滚动响应延迟问题
PMS: BUG-321325
Influence: 用户在帮助手册内容区域点击后，滚轮滚动立即响应，无需多次滚动。