### PR TITLE
fix(scrollbar): hide horizontal scrollbar and fix bottom content clipping

### DIFF
--- a/src/web/toManual/js/scrollbar.jsx
+++ b/src/web/toManual/js/scrollbar.jsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,9 +11,22 @@ function renderScrollBarTrackHorizontal(props) {
   );
 }
 
+function renderView(props) {
+  return (
+    <div {...props} style={Object.assign({}, props.style, { overflowX: 'hidden', marginBottom: 0 })} />
+  );
+}
+
 export default function(props) {
   return (
-    <Scrollbars {...props} className="scrollbar" autoHide renderTrackHorizontal={renderScrollBarTrackHorizontal} autoHideTimeout={800}>
+    <Scrollbars
+      {...props}
+      className="scrollbar"
+      autoHide
+      renderTrackHorizontal={renderScrollBarTrackHorizontal}
+      renderView={renderView}
+      autoHideTimeout={800}
+    >
       {props.children}
     </Scrollbars>
   );


### PR DESCRIPTION

Add renderView to disable horizontal overflow and remove negative marginBottom from react-custom-scrollbars that was clipping the last line of content in both nav and article areas.

添加 renderView 隐藏水平滚动条，移除 react-custom-scrollbars 的负 marginBottom， 修复左侧大纲和右侧内容区域最后一行被裁剪的问题。

Log: 修复水平滚动条和底部内容裁剪问题
PMS: BUG-342675
Influence: 隐藏水平滚动条，修复导航栏和内容区最后一行文本被遮挡一半的问题。