### PR TITLE
fix(scrollbar): prevent horizontal scrollbar and fix bottom content clipping

### DIFF
--- a/src/web/toManual/js/scrollbar.jsx
+++ b/src/web/toManual/js/scrollbar.jsx
@@ -12,8 +12,17 @@ function renderScrollBarTrackHorizontal(props) {
 }
 
 function renderView(props) {
+  // 修复水平滚动条和最后一行被遮挡问题：
+  // 1. overflowX: 'hidden' - 防止水平滚动条
+  // 2. marginBottom: 0 - 修复最后一行被遮挡（移除负边距）
+  // 注意：保留 marginRight 的负边距，不破坏 react-custom-scrollbars 隐藏滚动条的机制
+  const mergedStyle = Object.assign({}, props.style, {
+    overflowX: 'hidden',
+    marginBottom: 0
+  });
+
   return (
-    <div {...props} style={Object.assign({}, props.style, { overflowX: 'hidden', marginBottom: 0 })} />
+    <div {...props} style={mergedStyle} />
   );
 }
 

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -2550,7 +2550,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 exports.default = function (props) {
   return _react2.default.createElement(
     _reactCustomScrollbars.Scrollbars,
-    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, autoHideTimeout: 800 }),
+    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, renderView: renderView, autoHideTimeout: 800 }),
     props.children
   );
 };
@@ -2565,6 +2565,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function renderScrollBarTrackHorizontal(props) {
   return _react2.default.createElement('span', null);
+}
+
+function renderView(props) {
+  var mergedStyle = _extends({}, props.style, {
+    overflowX: 'hidden',
+    marginBottom: 0
+  });
+  return _react2.default.createElement('div', _extends({}, props, { style: mergedStyle }));
 }
 
 },{"react":74,"react-custom-scrollbars":35}],8:[function(require,module,exports){


### PR DESCRIPTION

Add renderView to customize view container style with overflowX: 'hidden'
and marginBottom: 0 to fix clipping issues.

添加 renderView 自定义视图容器样式，设置 overflowX: 'hidden' 和
marginBottom: 0 修复裁剪问题。

Log: 修复水平滚动条和底部内容裁剪问题
PMS: BUG-342675
Influence: 修复点击左侧大纲最后一个标题时出现水平滚动条的问题，
           修复左侧大纲和右侧内容区域最后一行被遮挡的问题。