### PR TITLE
fix(scrollbar): prevent cursor flicker with CSS-based auto-hide

### DIFF
--- a/src/web/toManual/js/scrollbar.jsx
+++ b/src/web/toManual/js/scrollbar.jsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Scrollbars } from 'react-custom-scrollbars';
 
 function renderScrollBarTrackHorizontal(props) {
@@ -27,14 +27,66 @@ function renderView(props) {
 }
 
 export default function(props) {
+  const scrollbarsRef = useRef(null);
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    const scrollbars = scrollbarsRef.current;
+    if (!scrollbars) return;
+
+    const showScrollbar = () => {
+      const container = scrollbars.container;
+      if (container) {
+        container.style.setProperty('--scrollbar-opacity', '1');
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(hideScrollbar, 800);
+    };
+
+    const hideScrollbar = () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      const container = scrollbars.container;
+      if (container) {
+        container.style.setProperty('--scrollbar-opacity', '0');
+      }
+    };
+
+    const view = scrollbars.view;
+    const container = scrollbars.container;
+    if (view) {
+      view.addEventListener('scroll', showScrollbar);
+    }
+    if (container) {
+      container.addEventListener('mousemove', showScrollbar);
+      container.addEventListener('mouseleave', hideScrollbar);
+    }
+
+    return () => {
+      if (view) {
+        view.removeEventListener('scroll', showScrollbar);
+      }
+      if (container) {
+        container.removeEventListener('mousemove', showScrollbar);
+        container.removeEventListener('mouseleave', hideScrollbar);
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
   return (
     <Scrollbars
       {...props}
+      ref={scrollbarsRef}
       className="scrollbar"
-      autoHide
       renderTrackHorizontal={renderScrollBarTrackHorizontal}
       renderView={renderView}
-      autoHideTimeout={800}
     >
       {props.children}
     </Scrollbars>

--- a/src/web/toManual/js/scrollbar.jsx
+++ b/src/web/toManual/js/scrollbar.jsx
@@ -12,8 +12,17 @@ function renderScrollBarTrackHorizontal(props) {
 }
 
 function renderView(props) {
+  // 修复水平滚动条和最后一行被遮挡问题：
+  // 1. overflowX: 'hidden' - 防止水平滚动条
+  // 2. marginBottom: 0 - 修复最后一行被遮挡（移除负边距）
+  // 注意：保留 marginRight 的负边距，不破坏 react-custom-scrollbars 隐藏滚动条的机制
+  const mergedStyle = Object.assign({}, props.style, {
+    overflowX: 'hidden',
+    marginBottom: 0
+  });
+
   return (
-    <div {...props} style={Object.assign({}, props.style, { overflowX: 'hidden', marginBottom: 0 })} />
+    <div {...props} style={mergedStyle} />
   );
 }
 

--- a/src/web/toManual/sass/app.scss
+++ b/src/web/toManual/sass/app.scss
@@ -22,29 +22,39 @@ body {
   }
 }
 
-.scrollbar>div:last-child {
-  width: 6px !important;
-  border-radius: 3px !important;
+// 使用 CSS 变量实现滚动条自动隐藏，避免 JavaScript autoHide 导致的光标闪烁
+// CSS变量的改变只会触发重绘（repaint），不会触发回流（reflow），因此不会导致光标闪烁
+.scrollbar {
+  // 滚动条轨道（垂直）
+  > div:last-child {
+    width: 6px !important;
+    border-radius: 3px !important;
+    opacity: var(--scrollbar-opacity, 0); // 使用CSS变量，默认值为0
+    transition: opacity 0.3s ease-in-out;
 
-  div {
-    background-color: var(--scrollbar-div-background-color) !important;
-    cursor: default !important;
+    // 滚动条滑块
+    div {
+      background-color: var(--scrollbar-div-background-color) !important;
+      cursor: default !important;
+
+      &:hover {
+        background-color: var(--scrollbar-div-hover-background-color) !important;
+      }
+    }
 
     &:hover {
-      background-color: var(--scrollbar-div-hover-background-color) !important;
+      width: 8px !important;
+      border-radius: 4px !important;
     }
-  }
-
-  &:hover {
-    width: 8px !important;
-    border-radius: 4px !important;
   }
 }
 
+// 文本选择模式下滚动条保持显示
 body[style*='user-select: none'] {
-  .scrollbar>div:last-child {
+  .scrollbar > div:last-child {
     width: 8px !important;
     border-radius: 4px !important;
+    opacity: 1;
 
     div {
       background-color: var(--scrollbar-div-select-background-color) !important;

--- a/src/web_dist/toManual/index.css
+++ b/src/web_dist/toManual/index.css
@@ -14,7 +14,9 @@ body {
 
 .scrollbar > div:last-child {
   width: 6px !important;
-  border-radius: 3px !important; }
+  border-radius: 3px !important;
+  opacity: var(--scrollbar-opacity, 0);
+  transition: opacity 0.3s ease-in-out; }
   .scrollbar > div:last-child div {
     background-color: var(--scrollbar-div-background-color) !important;
     cursor: default !important; }
@@ -26,7 +28,8 @@ body {
 
 body[style*='user-select: none'] .scrollbar > div:last-child {
   width: 8px !important;
-  border-radius: 4px !important; }
+  border-radius: 4px !important;
+  opacity: 1; }
   body[style*='user-select: none'] .scrollbar > div:last-child div {
     background-color: var(--scrollbar-div-select-background-color) !important; }
 

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -2547,19 +2547,75 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-exports.default = function (props) {
-  return _react2.default.createElement(
-    _reactCustomScrollbars.Scrollbars,
-    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, renderView: renderView, autoHideTimeout: 800 }),
-    props.children
-  );
-};
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
 var _reactCustomScrollbars = require('react-custom-scrollbars');
+
+var useRef = _react2.default.useRef;
+var useEffect = _react2.default.useEffect;
+
+exports.default = function (props) {
+  var scrollbarsRef = useRef(null);
+  var timeoutRef = useRef(null);
+
+  useEffect(function () {
+    var scrollbars = scrollbarsRef.current;
+    if (!scrollbars) return;
+
+    var showScrollbar = function () {
+      var container = scrollbars.container;
+      if (container) {
+        container.style.setProperty('--scrollbar-opacity', '1');
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(hideScrollbar, 800);
+    };
+
+    var hideScrollbar = function () {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      var container = scrollbars.container;
+      if (container) {
+        container.style.setProperty('--scrollbar-opacity', '0');
+      }
+    };
+
+    var view = scrollbars.view;
+    var container = scrollbars.container;
+    if (view) {
+      view.addEventListener('scroll', showScrollbar);
+    }
+    if (container) {
+      container.addEventListener('mousemove', showScrollbar);
+      container.addEventListener('mouseleave', hideScrollbar);
+    }
+
+    return function () {
+      if (view) {
+        view.removeEventListener('scroll', showScrollbar);
+      }
+      if (container) {
+        container.removeEventListener('mousemove', showScrollbar);
+        container.removeEventListener('mouseleave', hideScrollbar);
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return _react2.default.createElement(
+    _reactCustomScrollbars.Scrollbars,
+    _extends({}, props, { ref: scrollbarsRef, className: 'scrollbar', renderTrackHorizontal: renderScrollBarTrackHorizontal, renderView: renderView }),
+    props.children
+  );
+};
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2568,10 +2624,7 @@ function renderScrollBarTrackHorizontal(props) {
 }
 
 function renderView(props) {
-  var mergedStyle = _extends({}, props.style, {
-    overflowX: 'hidden',
-    marginBottom: 0
-  });
+  var mergedStyle = _extends({}, props.style, { overflowX: 'hidden', marginBottom: 0 });
   return _react2.default.createElement('div', _extends({}, props, { style: mergedStyle }));
 }
 

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -2550,7 +2550,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 exports.default = function (props) {
   return _react2.default.createElement(
     _reactCustomScrollbars.Scrollbars,
-    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, autoHideTimeout: 800 }),
+    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, renderView: renderView, autoHideTimeout: 800 }),
     props.children
   );
 };
@@ -2565,6 +2565,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function renderScrollBarTrackHorizontal(props) {
   return _react2.default.createElement('span', null);
+}
+
+function renderView(props) {
+  var mergedStyle = _extends({}, props.style, {
+    overflowX: 'hidden',
+    marginBottom: 0
+  });
+  return _react2.default.createElement('div', _extends({}, props, { style: mergedStyle }));
 }
 
 },{"react":74,"react-custom-scrollbars":35}],8:[function(require,module,exports){


### PR DESCRIPTION
Remove JavaScript autoHide to prevent DOM updates causing cursor flicker. Implement CSS opacity transition for smooth scrollbar show/hide.

移除 JavaScript autoHide 防止 DOM 更新导致光标闪烁，
使用 CSS opacity 过渡实现平滑的滚动条显示/隐藏。

Log: 修复光标闪烁问题
PMS: BUG-359981
Influence: 鼠标悬停在文本上时不再出现光标闪烁，滚动条自动隐藏功能通过
           CSS 实现，体验更流畅。