### PR TITLE
fix: Implement reconcileIncompleteIndex to manage stale filetime entries

### DIFF
--- a/src/controller/helpermanager.cpp
+++ b/src/controller/helpermanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,37 @@
 #include <QDBusMessage>
 #include <QtDBus>
 #include <QDBusConnection>
+#include <QFileInfo>
+
+namespace {
+
+bool parseAppLangFromMdPath(const QString &path, QString &appName, QString &lang)
+{
+    if (path.contains("video-guide")) {
+        return false;
+    }
+
+    const QStringList list = path.split("/");
+    if (list.count() < 4) {
+        return false;
+    }
+
+    if (systemType.contains(list.at(list.count() - 4))) {
+        lang = list.at(list.count() - 2);
+        appName = list.at(list.count() - 3);
+        return true;
+    }
+
+    if (list.contains("application") || list.contains("system")) {
+        lang = list.at(list.count() - 2);
+        appName = list.at(list.count() - 4);
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace
 
 helperManager::helperManager(QObject *parent)
     : QObject(parent)
@@ -165,6 +196,8 @@ void helperManager::getModuleInfo()
         qCDebug(app) << "File changed:" << kVideoConfigPath << "modifyTime:" << modifyTime;
     }
 
+    reconcileIncompleteIndex(mapFile, mapNow);
+
     QStringList deleteList;
     QStringList addList;
     QStringList addTime;
@@ -175,6 +208,48 @@ void helperManager::getModuleInfo()
     qCDebug(app) << "addList:" << addList;
     qCDebug(app) << "addTime:" << addTime;
     handleDb(deleteList, addList, addTime);
+}
+
+void helperManager::reconcileIncompleteIndex(QMap<QString, QString> &mapFile,
+                                             const QMap<QString, QString> &mapNow)
+{
+    QStringList stalePaths;
+
+    for (auto it = mapFile.constBegin(); it != mapFile.constEnd(); ++it) {
+        const QString &mdPath = it.key();
+        if (!mapNow.contains(mdPath)) {
+            continue;
+        }
+
+        if (mdPath == kVideoConfigPath) {
+            if (dbObj->searchEntryCount("video-guide", "zh_CN") == 0
+                    || dbObj->searchEntryCount("video-guide", "en_US") == 0) {
+                qCWarning(app) << "Incomplete video-guide index, will rebuild:" << mdPath;
+                stalePaths.append(mdPath);
+            }
+            continue;
+        }
+
+        QString appName;
+        QString lang;
+        if (!parseAppLangFromMdPath(mdPath, appName, lang)) {
+            continue;
+        }
+
+        if (dbObj->searchEntryCount(appName, lang) == 0) {
+            qCWarning(app) << "Incomplete search index, will rebuild:"
+                           << mdPath << "app:" << appName << "lang:" << lang;
+            stalePaths.append(mdPath);
+        }
+    }
+
+    if (!stalePaths.isEmpty()) {
+        dbObj->deleteFilesTimeEntry(stalePaths);
+        for (const QString &path : stalePaths) {
+            mapFile.remove(path);
+        }
+        qCDebug(app) << "Cleared stale filetime entries:" << stalePaths.size();
+    }
 }
 
 void helperManager::initConnect()
@@ -288,15 +363,18 @@ void helperManager::handleDb(const QStringList &deleteList, const QStringList &a
                 }
             }
         }
+        QFileInfo videoFileInfo(kVideoConfigPath);
+        if (videoFileInfo.exists()) {
+            dbObj->insertFileTimeEntry(kVideoConfigPath,
+                                       videoFileInfo.lastModified().toString("yyyy-MM-dd hh:mm:ss.zzz"));
+        }
     }
 
     QStringList list = handlePriority(tmpAddList);
     qCDebug(app) << "addList:" << list;
 
-    if (!list.isEmpty() && !addTime.isEmpty()) {
-        qCDebug(app) << "addTime:" << addTime;
-        dbObj->insertFilesTimeEntry(tmpAddList, addTime);
-        //通过JS层函数来完成md转html, 然后解析html内所有文本内容
+    if (!list.isEmpty()) {
+        // filetime 在 onRecvParseMsg 写入 search 成功之后；此处仅触发 md 解析
         if (jsObj && m_webView) {
             QString strChange = list.join(",");
             qCDebug(app) << strChange;
@@ -527,6 +605,13 @@ void helperManager::onRecvParseMsg(const QString &msg, const QString &path)
     if (!invalid_entry) {
         dbObj->addSearchEntry(appName, lang, anchors, anchorInitialList, anchorSpellList, anchorIdList, contents, path);
         qCDebug(app) << "addSearchEntry end";
+
+        QFileInfo fileInfo(path);
+        if (fileInfo.exists()) {
+            dbObj->insertFileTimeEntry(path,
+                                       fileInfo.lastModified().toString("yyyy-MM-dd hh:mm:ss.zzz"));
+            qCDebug(app) << "insertFileTimeEntry after addSearchEntry:" << path;
+        }
     }
     //获取内容解析返回 重置定时器
     timerObj->start();

--- a/src/controller/helpermanager.h
+++ b/src/controller/helpermanager.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,6 +37,9 @@ private:
     void dbusSend(const QStringList &deleteList, const QStringList &addList);
     //判断返回md文件符合优先选择。
     QStringList handlePriority(const QStringList &list);
+    // filetime 有记录但 search 无数据时，清除 filetime 以触发重建
+    void reconcileIncompleteIndex(QMap<QString, QString> &mapFile,
+                                const QMap<QString, QString> &mapNow);
 
 private slots:
     //文件列表发生改变信号槽

--- a/src/controller/search_db.cpp
+++ b/src/controller/search_db.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -906,6 +906,25 @@ void SearchDb::insertFilesTimeEntry(const QStringList &listMdPath, const QString
         qCCritical(app) << "insert fileTime" << ret;
     }
     qCDebug(app) << "insertFilesTimeEntry done";
+}
+
+void SearchDb::insertFileTimeEntry(const QString &mdPath, const QString &modifyTime)
+{
+    insertFilesTimeEntry(QStringList() << mdPath, QStringList() << modifyTime);
+}
+
+int SearchDb::searchEntryCount(const QString &appName, const QString &lang)
+{
+    Q_ASSERT(p_->db.isOpen());
+    QSqlQuery query(p_->db);
+    query.prepare("SELECT COUNT(*) FROM search WHERE appName=? AND lang=?");
+    query.bindValue(0, appName);
+    query.bindValue(1, lang);
+    if (query.exec() && query.next()) {
+        return query.value(0).toInt();
+    }
+    qCWarning(app) << "searchEntryCount failed:" << query.lastError().text();
+    return 0;
 }
 
 /**

--- a/src/controller/search_db.h
+++ b/src/controller/search_db.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -52,9 +52,12 @@ public slots:
     //文件信息插入数据库 （先删除数据，再插入数据）
     void insertFilesTimeEntry(const QStringList &listMdPath,
                               const QStringList &listDataTime);
+    void insertFileTimeEntry(const QString &mdPath, const QString &modifyTime);
 
     //根据mdPath删除表数据
     void deleteFilesTimeEntry(const QStringList &listMdPath);
+
+    int searchEntryCount(const QString &appName, const QString &lang);
 
     //查找filetime表所有内容, key:md文件路径 value: md文件更新时间
     QMap<QString, QString> selectAllFileTime();


### PR DESCRIPTION
- Added a new method to reconcile incomplete index entries in the database, ensuring that stale filetime entries are cleared when no corresponding search data exists.
- Introduced helper function to parse application language from metadata path.
- Enhanced filetime entry management in the database by adding methods for inserting single filetime entries and counting search entries.

Log: Implement reconcileIncompleteIndex for better filetime management.

bug: https://pms.uniontech.com/bug-view-362095.html