### PR TITLE
fix(search): preserve text selection when mouse released outside titl…

### DIFF
--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -521,7 +521,8 @@ bool WebWindow::eventFilter(QObject *watched, QEvent *event)
     if (event->type() == QEvent::MouseButtonRelease && qApp->activeWindow() == this) {
         qCDebug(app) << "eventFilter mouse release";
         QRect rect = hasWidgetRect(search_edit_);
-        if (web_view_ && web_view_->selectedText().isEmpty() && !rect.contains(QCursor::pos())) {
+        if (web_view_ && web_view_->selectedText().isEmpty() && !rect.contains(QCursor::pos())
+            && search_edit_->lineEdit()->selectedText().isEmpty()) {
             qCDebug(app) << "set focus to web view to maintain scroll responsiveness";
             web_view_->setFocus();
         }


### PR DESCRIPTION
…ebar

Check search edit selection before transferring focus to web view to prevent deselection caused by focus loss.

修复标题栏搜索框框选文本时，鼠标释放在标题栏外导致选中
被取消的问题，增加搜索框选中文本的判断条件。

Log: 修复搜索框框选文字被取消的问题
PMS: BUG-361733
Influence: 修复后用户在搜索框中拖拽框选文字，即使鼠标释放在标题栏外也不会丢失选中状态。

## Summary by Sourcery

Bug Fixes:
- Preserve text selection in the title bar search field when the mouse button is released outside the search area by avoiding unnecessary focus transfer to the web view.