### PR TITLE
fix(window): persist maximized state and center window on startup

### DIFF
--- a/src/base/consts.cpp
+++ b/src/base/consts.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,7 @@ const char kSearchIndexPage[] = DMAN_WEB_DIR "/toSearchMd/index.html";
 
 const char kConfigWindowWidth[] = "window_width";
 const char kConfigWindowHeight[] = "window_height";
+const char kConfigWindowMaximized[] = "window_maximized";
 const char kConfigWindowInfo[] = "window_info";
 const char kConfigAppList[] = "AppList";
 

--- a/src/base/consts.h
+++ b/src/base/consts.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +15,7 @@ extern const char kSearchIndexPage[];
 
 extern const char kConfigWindowWidth[];
 extern const char kConfigWindowHeight[];
+extern const char kConfigWindowMaximized[];
 extern const char kConfigWindowInfo[];
 extern const char kConfigAppList[];
 

--- a/src/controller/window_manager.cpp
+++ b/src/controller/window_manager.cpp
@@ -15,6 +15,8 @@
 #include <DWidgetUtil>
 
 #include <QApplication>
+#include <QGuiApplication>
+#include <QScreen>
 
 #define WM_SENDER_NAME "Sender"
 const int kWinMinWidth = 680;
@@ -199,6 +201,7 @@ void WindowManager::setWindow(WebWindow *window)
     setting->beginGroup(QString(kConfigWindowInfo));
     int saveWidth = setting->value(QString(kConfigWindowWidth)).toInt();
     int saveHeight = setting->value(QString(kConfigWindowHeight)).toInt();
+    bool saveMaximized = setting->value(QString(kConfigWindowMaximized)).toBool();
     setting->endGroup();
     // 如果配置文件没有数据
     if (saveWidth == 0 || saveHeight == 0) {
@@ -212,6 +215,17 @@ void WindowManager::setWindow(WebWindow *window)
 
     qCDebug(app) << "Setting minimum window size to:" << kWinMinWidth << "x" << kWinMinHeight;
     window->setMinimumSize(kWinMinWidth, kWinMinHeight);
+
+    // 获取当前屏幕可用区域（已排除Dock栏占用区域）
+    QRect screenRect = QGuiApplication::primaryScreen()->availableGeometry();
+
+    if (saveMaximized || (saveWidth > screenRect.width() && saveHeight > screenRect.height())) {
+        // 上次关闭时最大化 或 保存的窗口尺寸宽和高均大于屏幕可用区域，直接最大化
+        window->showMaximized();
+    } else {
+        // 屏幕居中显示
+        Dtk::Widget::moveToCenter(window);
+    }
 
     qCDebug(app) << "Window properties configured successfully";
 }

--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -941,11 +941,20 @@ void WebWindow::saveWindowSize()
 {
     qCDebug(app) << "Saving window size";
     QSettings *setting = ConfigManager::getInstance()->getSettings();
+    bool isMaximized = windowState() & Qt::WindowMaximized;
     setting->beginGroup(QString(kConfigWindowInfo));
-    setting->setValue(QString(kConfigWindowWidth), width());
-    setting->setValue(QString(kConfigWindowHeight), height());
+    if (isMaximized) {
+        // 最大化时保存正常状态下的几何信息，以便恢复时使用正确尺寸
+        setting->setValue(QString(kConfigWindowWidth), normalGeometry().width());
+        setting->setValue(QString(kConfigWindowHeight), normalGeometry().height());
+    } else {
+        setting->setValue(QString(kConfigWindowWidth), width());
+        setting->setValue(QString(kConfigWindowHeight), height());
+    }
+    setting->setValue(QString(kConfigWindowMaximized), isMaximized);
+    setting->sync();
     setting->endGroup();
-    qCDebug(app) << "Window size saved";
+    qCDebug(app) << "Window size saved, maximized:" << isMaximized;
 }
 /**
  * @brief WebWindow::updateDb 更新数据库


### PR DESCRIPTION
Save window maximized state to config and restore on next launch. Use normalGeometry() when maximized and sync() before _Exit(). Add screen centering and auto-maximize when size exceeds screen.

持久化窗口最大化状态，重启后恢复最大化或居中显示窗口。
最大化时使用 normalGeometry() 保存正常尺寸，添加 sync() 确
保配置在 _Exit() 前写入磁盘。

Log: 修复重启后窗口未恢复最大化状态的问题
PMS: BUG-340035
Influence: 窗口关闭时保存最大化状态，重新打开时恢复最大化；非最大化窗口居中显示；窗口尺寸超过屏幕时自动最大化。