### PR TITLE
fix(index): clamp app card title to prevent overflow

### DIFF
--- a/src/web/toManual/sass/index.scss
+++ b/src/web/toManual/sass/index.scss
@@ -85,15 +85,16 @@
       }
 
       .content {
-        //margin-left: 15px;    //保持span居中,当设置display:-webkit-box后,默认居左,故设置其外边距
         width: var(--index-span-width);
         word-break: normal;
         overflow: hidden;
         text-overflow: ellipsis;
         margin: auto;
-        //display:-webkit-box;    //设置其排列两行
+        display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
+        overflow-wrap: break-word;
+        text-align: center;
         font-family: var(--nav-world-font-family);
         font-size: var(--span-font-size);
         line-height: var(--span-line-height);

--- a/src/web_dist/toManual/index.css
+++ b/src/web_dist/toManual/index.css
@@ -387,8 +387,11 @@ div {
         overflow: hidden;
         text-overflow: ellipsis;
         margin: auto;
+        display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
+        overflow-wrap: break-word;
+        text-align: center;
         font-family: var(--nav-world-font-family);
         font-size: var(--span-font-size);
         line-height: var(--span-line-height);


### PR DESCRIPTION
Restore CSS line clamp for app card titles with centered layout and word wrapping, preventing long English names from overflowing the card background while keeping the previous auto-centering behavior.

恢复应用卡片标题的CSS两行截断，并保持居中与长词换行能力。
避免英文长名称超出卡片背景，同时保留此前为多语言显示调整的自动居中效果。

bug-368193

Log: 恢复应用卡片标题CSS截断修复英文长名称超出背景
PMS: BUG-359981
Influence: 应用卡片标题超过两行时省略显示，解决长英文名称溢出问题，不影响图标与卡片点击功能。

## Summary by Sourcery

Bug Fixes:
- Prevent long app card titles from overflowing the card background by re-enabling CSS line clamping and word wrapping.