### PR TITLE
fix(index): align dmanHelper md prefix selection with manual open logic

### DIFF
--- a/src/controller/helpermanager.cpp
+++ b/src/controller/helpermanager.cpp
@@ -428,7 +428,7 @@ void helperManager::dbusSend(const QStringList &deleteList, const QStringList &a
 QStringList helperManager::handlePriority(const QStringList &list)
 {
     qCDebug(app) << list;
-    QStringList omitType = Utils::systemToOmit(Utils::uosEditionType());
+    QStringList omitType = Utils::systemToOmitCompat(Utils::uosEditionType());
     qCDebug(app) << omitType;
     QStringList moduleList;
     QStringList retList;


### PR DESCRIPTION
Use systemToOmitCompat() when dmanHelper selects markdown files for search indexing, keeping it consistent with dman manual opening logic. This allows non-community editions such as Education to index p_ prefixed manual files when no edu_ files exist, preventing searchable content like deepin-movie from being skipped during index generation.

同步 dmanHelper 搜索索引构建时的文档前缀选择逻辑，使其与 dman 主程序
打开手册时保持一致。教育版等非社区版本将按 p_ 前缀建立索引，避免因
仅匹配 edu_ 前缀导致 deepin-movie 等应用文档未写入搜索库。

Log: 修复教育版环境下部分应用文档未建立搜索索引导致搜索不到的问题
PMS: BUG-369331

Influence: 影响 dmanHelper 搜索索引构建逻辑，使搜索索引选择的文档版本与手册打开逻辑一致；解决教育版环境下 deepin-movie 等仅提供 p_/d_ 文档的应用无法被搜索到的问题，不影响手册打开、应用列表展示及已有搜索查询流程。