### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/resources/deepin-manual.desktop
+++ b/src/resources/deepin-manual.desktop
@@ -140,7 +140,7 @@ Name[tr]=Deepin Kılavuz
 Name[ug]= قوللانمىسى  Deepin
 Name[uk]=Підручник Deepin
 Name[lo]=ຄູ່ມືການໃຊ້
-Name[zh_CN]=深度帮助手册
-Name[zh_HK]=Deepin 幫助手冊
-Name[zh_TW]=Deepin 說明書
+Name[zh_CN]=帮助手册
+Name[zh_HK]=幫助手冊
+Name[zh_TW]=說明書
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop file translations so application names and descriptions no longer include redundant deepin brand prefixes.