### PR TITLE
fix: correct desktopname in zh_CN basic-operations markdown

### DIFF
--- a/manual-assets/learn-basic-operations/basic-operations/zh_CN/basic-operations.md
+++ b/manual-assets/learn-basic-operations/basic-operations/zh_CN/basic-operations.md
@@ -1,4 +1,4 @@
-# 如何快速上手UOS|Get started with UOS|
+# 如何快速上手UOS|learn-basic-operations|
 
 ![welcome](./fig/welcome-screen.png)
 


### PR DESCRIPTION
Fix the desktopname field in zh_CN basic-operations.md which was mistakenly set to "Get started with UOS" instead of the expected "learn-basic-operations", causing the search result icon to fail loading and the title to display raw text.

修复 zh_CN 版 basic-operations.md 首行的 desktopname 字段，原值 "Get started with UOS" 应为 "learn-basic-operations"，导致搜索 结果界面图标损坏、标题显示为英文原文。

Log: 修复 zh_CN 快速入门文档 desktopname 字段错误导致搜索结果图标异常
PMS: BUG-363959
Influence: 搜索"文件管理器"/"全局搜索"时该文档图标显示为损坏图样且标题显示为英文

## Summary by Sourcery

Documentation:
- Fix the desktopname field in the zh_CN basic-operations guide so that search results show the correct icon and localized title.