### PR TITLE
fix: 可配置显示服务与支持

### DIFF
--- a/manual-assets/org.deepin.manual.customui.json
+++ b/manual-assets/org.deepin.manual.customui.json
@@ -1,0 +1,16 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "selperSupport": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "selperSupport",
+            "description[zh_CN]": "是否显示服务与支持",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,6 +319,15 @@ install(TARGETS dman
 install(TARGETS dmanHelper
         DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
+##dconfig
+set(APPID org.deepin.manual)
+set(configFile ${CMAKE_SOURCE_DIR}/manual-assets/org.deepin.manual.customui.json)
+if (DEFINED DSG_DATA_DIR)
+    message("-- DConfig is supported by DTK")
+    dtk_add_config_meta_files(APPID ${APPID} FILES ${configFile})
+else()
+    install(FILES ${configFile} DESTINATION ${CMAKE_INSTALL_DATADIR}/dsg/configs/org.deepin.manual/)
+endif()
 
 # translation files
 TRANSLATION_GENERATE(QM_FILES ${CMAKE_SOURCE_DIR}/translations)

--- a/src/base/utils.cpp
+++ b/src/base/utils.cpp
@@ -10,6 +10,10 @@ DCORE_USE_NAMESPACE
 
 #include <QFontDatabase>
 #include <QImageReader>
+#include <QScopedPointer>
+#ifdef DTKCORE_CLASS_DConfigFile
+#include <DConfig>
+#endif
 
 #include "base/consts.h"
 
@@ -532,11 +536,18 @@ bool Utils::hasSelperSupport()
 {
     qCDebug(app) << "hasSelperSupport";
     Dtk::Core::DSysInfo::UosEdition type = uosEditionType();
+    bool bSelperSupport = true;
+#ifdef DTKCORE_CLASS_DConfigFile
+    QScopedPointer<DConfig> dconfig(DConfig::create("org.deepin.manual", "org.deepin.manual.customui"));
+    if (dconfig && dconfig->isValid() && dconfig->keyList().contains("selperSupport")) {
+       bSelperSupport = dconfig->value("selperSupport").toBool();
+    }
+#endif
     //专业版判断是否有服务与支持
     if (Dtk::Core::DSysInfo::UosProfessional == type || Dtk::Core::DSysInfo::UosMilitary == type || Dtk::Core::DSysInfo::UosMilitaryS == type) {
         qCDebug(app) << "hasSelperSupport true";
         const QStringList list = getSystemManualList();
-        if (list.contains("uos-service-support")) {
+        if (list.contains("uos-service-support") && bSelperSupport) {
             qCDebug(app) << "uos-service-support found in manual list";
             return true;
         }


### PR DESCRIPTION
可配置显示服务与支持

pick from: 11012500cc9714f9f339b6b3080ee280b2a755dd

Task: https://pms.uniontech.com/task-view-374189.html
Log: 可配置显示服务与支持

## Summary by Sourcery

Make the display of the service and support entry configurable via DConfig for specific UOS editions.

Enhancements:
- Read a DConfig setting to control whether the service and support entry is considered available on supported UOS editions.

Build:
- Integrate a DConfig metadata JSON file into the build and installation process for org.deepin.manual.