### PR TITLE
chore: Update version to 6.5.56

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+deepin-manual (6.5.56) unstable; urgency=medium
+
+  * chore: Update version to 6.5.56
+  * fix: 可配置显示服务与支持
+  * chore(ci): update actions/checkout to v7 and enable unsafe PR checkout
+  * fix: remove deepin prefix from Chinese translations in desktop file
+  * [skip CI] Translate desktop.ts in it
+  * [skip CI] Translate deepin-manual.ts in it
+  * [skip CI] Translate deepin-manual.ts in it
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:27:50 +0800
+
 deepin-manual (6.5.55) unstable; urgency=medium
 
   * fix: resolve DDE help topics with fallback candidates

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.manual
   name: "deepin-manual"
-  version: 6.5.55.1
+  version: 6.5.56.1
   kind: app
   description: |
     manual for deepin os.


### PR DESCRIPTION
- update version to 6.5.56

log: update version to 6.5.56

## Summary by Sourcery

Bump deepin-manual package version metadata to 6.5.56.1 across packaging configuration.