### PR TITLE
fix: show service & support entry on education edition

### DIFF
--- a/src/base/utils.cpp
+++ b/src/base/utils.cpp
@@ -422,7 +422,10 @@ bool Utils::hasSelperSupport()
     }
 #endif
     //专业版判断是否有服务与支持
-    if (Dtk::Core::DSysInfo::UosProfessional == type || Dtk::Core::DSysInfo::UosMilitary == type || Dtk::Core::DSysInfo::UosMilitaryS == type) {
+    if (Dtk::Core::DSysInfo::UosProfessional == type
+            || Dtk::Core::DSysInfo::UosMilitary == type
+            || Dtk::Core::DSysInfo::UosMilitaryS == type
+            || Dtk::Core::DSysInfo::UosEducation == type) {
         const QStringList list = getSystemManualList();
         if (list.contains("uos-service-support") && bSelperSupport) {
             return true;


### PR DESCRIPTION
## 根因分析

帮助手册（deepin-manual）页面右下角"服务与支持"入口在教育版上缺失。根因是 `src/base/utils.cpp` 的 `Utils::hasSelperSupport()` 函数版本判断条件遗漏了 `UosEducation`，仅允许 `UosProfessional`/`UosMilitary`/`UosMilitaryS`。

**关键证据**：
- `src/base/utils.cpp:428` — `if` 条件仅含 Professional/Military/MilitaryS，教育版直接 `return false`
- 完整调用链：Web 前端 → `ManualProxy::hasSelperSupport()` → `Utils::hasSelperSupport()` → 前端条件渲染入口
- `UosEducation` 在同文件其他函数（`getSystemManualList()`、`systemToOmit()`）中已正常使用

## 修复方案

在 `hasSelperSupport()` 的版本判断条件中加入 `UosEducation`。修复后教育版仍会检查 `uos-service-support` 应用是否已安装，且保留 DConfig `selperSupport` 开关。

## 改动安全评估

低风险。仅在一个 `if` 条件中增加一个枚举值判断，不改变函数签名，不影响已有版本（专业版/军用版）的行为。

## PMS

https://pms.uniontech.com/bug-view-292317.html

## Summary by Sourcery

Bug Fixes:
- Ensure the 服务与支持 entry is available on the education edition by treating UosEducation as eligible in the hasSelperSupport() version check.