### PR TITLE
fix: preserve spaces in search keyword for multi-word search

### DIFF
--- a/src/view/web_window.cpp
+++ b/src/view/web_window.cpp
@@ -875,7 +875,7 @@ void WebWindow::onSearchContentByKeyword(const QString &keyword)
 {
     qDebug() << "calling keyword is:" << keyword << endl;
     QString key(keyword);
-    const QString searchKey = key.remove('\n').remove('\r').remove("\r\n").remove(QRegExp("\\s"));
+    const QString searchKey = key.simplified();
     //在数据库中查询->SearchDb::searchContent->SearchDb::handleSearchContent
     search_manager_->searchContent(searchKey);
 
@@ -944,7 +944,7 @@ void WebWindow::onSearchTextChanged(const QString &text)
 void WebWindow::onSearchTextChangedDelay()
 {
     QString textTemp = search_edit_->text();
-    const QString text = textTemp.remove('\n').remove('\r').remove("\r\n").remove(QRegExp("\\s"));
+    const QString text = textTemp.simplified();
     // 过滤特殊字符
     if (text.size() < 1 || text.toLower().contains(QRegExp("[+-_$!@#%^&\\(\\)]"))) {
         return;
@@ -965,7 +965,7 @@ void WebWindow::onTitleBarEntered()
 {
     qDebug() << Q_FUNC_INFO;
     QString textTemp = search_edit_->text();
-    const QString text = textTemp.remove('\n').remove('\r').remove("\r\n").remove(QRegExp("\\s"));
+    const QString text = textTemp.simplified();
     if (text.size() >= 1) {
         completion_window_->onEnterPressed();
     }


### PR DESCRIPTION
## 根因分析

帮助手册搜索框输入多词关键词（如英文环境下 "File Manager"）回车提交后，词间空格被整体剔除，"File Manager" 退化为 "FileManager"，导致全文检索无法命中正文短语、结果缺失/无结果。

**根因（唯一）**：`src/view/web_window.cpp:878` `WebWindow::onSearchContentByKeyword` 中

```cpp
const QString searchKey = key.remove('\n').remove('\r').remove("\r\n").remove(QRegExp("\\s"));
```

`QRegExp("\\s")` 匹配 `[ \t\n\v\f\r]`，**包含词间普通空格**，故多词被压成单词。该函数是全文检索唯一汇聚点——`searchContent(searchKey)`（DB 查询）与 `openSearchPage(base64Key)`（JS 路由/高亮）共用这个去空格后的串。

**关键证据**：
- 回车路径：`SearchEdit::enterPressed` → `onTitleBarEntered`(964) → `onEnterPressed` → 默认无选中项 → `searchButtonClicked` → `onSearchButtonClicked`(904，仅删换行) → `onSearchContentByKeyword`(874，**878 删 `\s` 退化**)。
- DB 层反证：`search_db.cpp` 全文 SQL 为 `LIKE '%/:content%'` 子串匹配，`handleSearchContent` 不裁剪关键词——保留空格即可命中正文短语。根因不在 DB。
- `search_proxy.cpp`/`search_manager.cpp` 仅信号转发，不裁剪；前端 JS 接收 C++ 已去空格的 base64，不主动删空格。

## 修复方案

将 `web_window.cpp` 中 3 处删除所有空白字符的链式 `remove(...).remove(QRegExp("\\s"))` 替换为 `QString::simplified()`：

| 行号 | 函数 | 改动 |
|------|------|------|
| 878 | `onSearchContentByKeyword`（根因行） | `key.simplified()` |
| 947 | `onSearchTextChangedDelay`（输入联想+按钮文案） | `textTemp.simplified()` |
| 968 | `onTitleBarEntered`（回车门控） | `textTemp.simplified()` |

`simplified()` 去首尾空白、将内部连续空白折叠为单空格，既满足原"清理换行/空白"意图又保留多词空格。改后 "File Manager" → "File Manager"，DB 执行 `LIKE '%File Manager%'` 命中正文短语，前端路由/高亮同步正确。无需改动 `search_db.cpp`、`search_proxy.cpp`、`search_manager.cpp` 及前端 JS。

## 改动安全评估

**低风险**。未改任何函数签名（`onSearchContentByKeyword`/`onSearchTextChangedDelay`/`onTitleBarEntered` 签名与返回值不变），调用者（`onManualSearchByKeyword`、`onSearchButtonClicked`）按值/const 引用传递，不受影响。blame 显示 3 处目标行归属基线提交 `1ef9c40`（主题为"教育版服务与支持入口"，与搜索无关），`.remove(QRegExp("\\s"))` 是长期存在的过度裁剪逻辑本身，**非撤销任何历史修复**，无回归风险。

**语义差异复核**：原 `remove` 直接删除内部 `\n\r\t`，`simplified()` 折叠为单空格。但 `search_edit_` 为 `DSearchEdit`（内部 `QLineEdit`，单行输入），不产生内部 `\n\r\t`，故差异实际影响为零；纯空格输入 `simplified()` 返回空串，947/968 的判空门控（`size() < 1` / `size() >= 1`）行为不变。

## 改动概览

```
src/view/web_window.cpp | 6 +++---
1 file changed, 3 insertions(+), 3 deletions(-)
```

PMS: BUG-373531（https://pms.uniontech.com/bug-view-373531.html）

## Summary by Sourcery

Preserve spaces in multi-word help manual search keywords so that full-text search and frontend routing/highlighting work correctly.

Bug Fixes:
- Fix multi-word search keywords being collapsed by whitespace removal in the full-text search entry point.
- Align search box change handling and enter key handling with the new whitespace-preserving keyword normalization.