### PR TITLE
fix: PMS-248195 修复最大号字体下帮助手册内容最后一行被遮挡

### DIFF
--- a/src/web/toManual/js/scrollbar.jsx
+++ b/src/web/toManual/js/scrollbar.jsx
@@ -11,9 +11,31 @@ function renderScrollBarTrackHorizontal(props) {
   );
 }
 
+function renderView(props) {
+  // 修复水平滚动条和最后一行被遮挡问题：
+  // 1. overflowX: 'hidden' - 防止水平滚动条
+  // 2. marginBottom: 0 - 修复最后一行被遮挡（移除负边距）
+  // 注意：保留 marginRight 的负边距，不破坏 react-custom-scrollbars 隐藏滚动条的机制
+  const mergedStyle = Object.assign({}, props.style, {
+    overflowX: 'hidden',
+    marginBottom: 0
+  });
+
+  return (
+    <div {...props} style={mergedStyle} />
+  );
+}
+
 export default function(props) {
   return (
-    <Scrollbars {...props} className="scrollbar" autoHide renderTrackHorizontal={renderScrollBarTrackHorizontal} autoHideTimeout={800}>
+    <Scrollbars
+      {...props}
+      className="scrollbar"
+      autoHide
+      renderTrackHorizontal={renderScrollBarTrackHorizontal}
+      renderView={renderView}
+      autoHideTimeout={800}
+    >
       {props.children}
     </Scrollbars>
   );

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -2550,7 +2550,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 exports.default = function (props) {
   return _react2.default.createElement(
     _reactCustomScrollbars.Scrollbars,
-    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, autoHideTimeout: 800 }),
+    _extends({}, props, { className: 'scrollbar', autoHide: true, renderTrackHorizontal: renderScrollBarTrackHorizontal, renderView: renderView, autoHideTimeout: 800 }),
     props.children
   );
 };
@@ -2565,6 +2565,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function renderScrollBarTrackHorizontal(props) {
   return _react2.default.createElement('span', null);
+}
+
+function renderView(props) {
+  var mergedStyle = _extends({}, props.style, {
+    overflowX: 'hidden',
+    marginBottom: 0
+  });
+  return _react2.default.createElement('div', _extends({}, props, { style: mergedStyle }));
 }
 
 },{"react":74,"react-custom-scrollbars":35}],8:[function(require,module,exports){


### PR DESCRIPTION
# PMS-248195 修复：最大号字体下帮助手册内容最后一行被遮挡

> 目标分支：`release/eagle`（1070 专业版发布线）
> 源仓库：`linuxdeepin/deepin-manual`
> 关联 PMS：https://pms.uniontech.com/bug-view-248195.html
> 同源上游修复：master `8bd3cee` / `39a025d`（PMS BUG-342675）

## 根因分析

deepin-manual 的内容页（`src/web/toManual/js/article.jsx` 的 `render()`）与左侧大纲（`nav.jsx`）的正文都包在自研 `<Scrollbar>`（`react-custom-scrollbars`）中。在 `release/eagle` 上 `scrollbar.jsx:14-20` 的 `<Scrollbars>` **未传 `renderView`**，库默认给视图容器加**负向 `marginBottom`**（用于隐藏原生滚动条槽），导致滚动到底部时**正文（与大纲）最后一行被裁剪**。

最大号字体放大链：`web_window.cpp` 在 `QEvent::FontChange`/首屏发出 `fontChangeRequested(family, pixelSize)` → `App.js:202 onFontChange` 设根 `rem = pixelSize`，正文按 `rem` 整体放大、总高显著增加；`onFontChange` 在 `fontSize>=18` 时仅调首页索引网格，不对正文/滚动容器自适应。最大号字体下正文必溢出、必滚到底，最后一行被负 `marginBottom` 裁剪 → "开始使用"页显示不全，必现。

关键证据：
- `release/eagle:scrollbar.jsx:14-20` 无 `renderView`；master 同文件 `:14-27` 已加 `renderView`(`overflowX:'hidden'`+`marginBottom:0`)。
- master 已有同类缺陷修复 `39a025d`(2026-04-28)、`8bd3cee`(2026-05-09)，PMS BUG-342675，提交说明原文："remove negative marginBottom from react-custom-scrollbars that was clipping the last line of content…修复导航栏和内容区最后一行文本被遮挡一半"。
- `release/eagle` 未合入该修复（`scrollbar.jsx` 中 `renderView` 计数为 0）。

## 修复方案

镜像 master `8bd3cee` 的两文件改动回填到 `release/eagle`：
1. `src/web/toManual/js/scrollbar.jsx`：新增 `renderView` 函数，设置视图容器 `overflowX:'hidden'` + `marginBottom:0`，并向 `<Scrollbars>` 传入 `renderView={renderView}`；保留既有 `autoHide`/`renderTrackHorizontal`/`autoHideTimeout` 及 `marginRight` 负边距（不破坏滚动条自动隐藏机制）。
2. `src/web_dist/toManual/index.js`：同步等价的 webpack 构建产物改动（结构与 master 预修复态逐行一致，已比对，无需重新执行 node/gulp 构建）。

不携带 master 上其后另一次 CSS 化自动隐藏重写（`7f3e887`，与本 bug 无关），避免越界改动。

## 改动安全评估

**低风险。** 纯新增 `renderView`，不改任何函数签名、不删除公开成员；受影响调用者仅 2 处（`article.jsx`、`nav.jsx`），均为正向修复；等价改动已在 master 验证（PMS BUG-342675）。详见附件 `change-safety.md`。

## 验证建议

修复后请在 1070 复现环境验证：系统字体设为最大号 → 打开帮助手册 → 进入最后一个标题"开始使用"页滚到底 → 底部最后一行不再被截断。

## Summary by Sourcery

Fix clipping of the last line of help manual content and unwanted horizontal scrollbar by updating the custom Scrollbar view configuration.

Bug Fixes:
- Ensure the last line of help manual content and navigation text is fully visible when using the largest system font size.
- Prevent horizontal scrollbars from appearing in the manual content area by adjusting the scroll view styling.

Enhancements:
- Align the release/eagle scrollbar behavior with the verified fix already present on master by introducing a custom renderView implementation.