### PR TITLE
fix: correct dark-theme tips styling and add css var fallback

### DIFF
--- a/src/web/toManual/js/App.js
+++ b/src/web/toManual/js/App.js
@@ -635,9 +635,9 @@ class App extends React.Component {
                 document.documentElement.style.setProperty(`--search-WikiSearch-color`, '#6D7C88');
                 document.documentElement.style.setProperty(`--search-itemTitle-word-color`, '#C0C6D4');
                 document.documentElement.style.setProperty(`--search-context-word-color`, '#6D7C88');
-                document.documentElement.style.setProperty(`--tips-background-color`, 'rgba(42, 42, 42, 0.8)');
-                document.documentElement.style.setProperty(`--tips-border-color`, 'rgba(0, 0, 0, 0.3)');
-                document.documentElement.style.setProperty('--tips-shadow-color', 'rgba(0, 0, 0, 0.2)');
+                document.documentElement.style.setProperty(`--tips-background-color`, 'rgba(56, 56, 56, 0.95)');
+                document.documentElement.style.setProperty(`--tips-border-color`, 'rgba(255, 255, 255, 0.12)');
+                document.documentElement.style.setProperty('--tips-shadow-color', 'rgba(0, 0, 0, 0.45)');
             } else if ("LightType" == themeType) {
                 console.log('LightType');
                 document.documentElement.style.setProperty(`--nav-hover-color`, 'rgba(0,0,0,0.1)');

--- a/src/web/toManual/sass/index.scss
+++ b/src/web/toManual/sass/index.scss
@@ -152,7 +152,8 @@
       color: var(--nav-hove-word-color);
       font-family: var(--nav-world-font-family);
       border-radius: 8px;
-      border: 1px solid var(--nav-hove-border-color);
+      border: 1px solid var(--tips-border-color);
+      box-shadow: 0px 3px 20px var(--tips-shadow-color);
     }
 
     .quickitem {
@@ -259,7 +260,8 @@
           z-index: 10;
           padding: 2px 5px;
           border-radius: 18px;
-          border: 1px solid var(--nav-hove-border-color);
+          border: 1px solid var(--tips-border-color);
+          box-shadow: 0px 3px 20px var(--tips-shadow-color);
           font-family: var(--nav-world-font-family);
         }
 

--- a/src/web/toManual/sass/main.scss
+++ b/src/web/toManual/sass/main.scss
@@ -4,6 +4,16 @@
 
 @charset "utf-8";
 
+// tips/tooltip 主题变量静态回退默认值：仅 setTheme() 运行时赋值，
+// 异步加载窗口或 getTheme() 返回 "Null" 时用此兜底，避免 var(--tips-*)
+// 回退 CSS 初始值导致透明背景 + 继承黑文字。取深色基调（与深色 webview 背景可读）。
+:root {
+  --tips-background-color: rgba(56, 56, 56, 0.95);
+  --tips-border-color: rgba(255, 255, 255, 0.12);
+  --tips-shadow-color: rgba(0, 0, 0, 0.45);
+  --nav-hove-word-color: #C0C6D4;
+}
+
 //去除最外层滚动条
 body {
   overflow: hidden;
@@ -30,6 +40,7 @@ body {
     color: var(--nav-hove-word-color);
     font-family: var(--nav-world-font-family);
     border-radius: 8px;
-    border: 1px solid var(--nav-hove-border-color);
+    border: 1px solid var(--tips-border-color);
+    box-shadow: 0px 3px 20px var(--tips-shadow-color);
   }
 }

--- a/src/web_dist/toManual/index.css
+++ b/src/web_dist/toManual/index.css
@@ -1,3 +1,9 @@
+:root {
+  --tips-background-color: rgba(56, 56, 56, 0.95);
+  --tips-border-color: rgba(255, 255, 255, 0.12);
+  --tips-shadow-color: rgba(0, 0, 0, 0.45);
+  --nav-hove-word-color: #C0C6D4; }
+
 body {
   background-color: var(--body-background-color);
   width: 100%;
@@ -427,7 +433,8 @@ div {
       color: var(--nav-hove-word-color);
       font-family: var(--nav-world-font-family);
       border-radius: 8px;
-      border: 1px solid var(--nav-hove-border-color); }
+      border: 1px solid var(--tips-border-color);
+      box-shadow: 0px 3px 20px var(--tips-shadow-color); }
     #index .items .quickitem {
       position: relative;
       border-radius: 18px;
@@ -511,7 +518,8 @@ div {
           z-index: 10;
           padding: 2px 5px;
           border-radius: 18px;
-          border: 1px solid var(--nav-hove-border-color);
+          border: 1px solid var(--tips-border-color);
+          box-shadow: 0px 3px 20px var(--tips-shadow-color);
           font-family: var(--nav-world-font-family); }
         #index .items .videoitem .title-div .title-wrapper.show {
           visibility: visible; }
@@ -550,7 +558,8 @@ body {
   color: var(--nav-hove-word-color);
   font-family: var(--nav-world-font-family);
   border-radius: 8px;
-  border: 1px solid var(--nav-hove-border-color); }
+  border: 1px solid var(--tips-border-color);
+  box-shadow: 0px 3px 20px var(--tips-shadow-color); }
 
 #nav {
   margin: 0 0 0 0;

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -731,9 +731,9 @@ var App = function (_React$Component) {
                     document.documentElement.style.setProperty('--search-WikiSearch-color', '#6D7C88');
                     document.documentElement.style.setProperty('--search-itemTitle-word-color', '#C0C6D4');
                     document.documentElement.style.setProperty('--search-context-word-color', '#6D7C88');
-                    document.documentElement.style.setProperty('--tips-background-color', 'rgba(42, 42, 42, 0.8)');
-                    document.documentElement.style.setProperty('--tips-border-color', 'rgba(0, 0, 0, 0.3)');
-                    document.documentElement.style.setProperty('--tips-shadow-color', 'rgba(0, 0, 0, 0.2)');
+                    document.documentElement.style.setProperty('--tips-background-color', 'rgba(56, 56, 56, 0.95)');
+                    document.documentElement.style.setProperty('--tips-border-color', 'rgba(255, 255, 255, 0.12)');
+                    document.documentElement.style.setProperty('--tips-shadow-color', 'rgba(0, 0, 0, 0.45)');
                 } else if ("LightType" == themeType) {
                     console.log('LightType');
                     document.documentElement.style.setProperty('--nav-hover-color', 'rgba(0,0,0,0.1)');


### PR DESCRIPTION
## 根因

PMS #243239：深色主题下帮助手册 tips（悬浮提示）控件背景样式与文字颜色不符合 UI 设计。deepin-manual 为 Qt C++ + QWebEngine 应用，tips 由 `src/web/toManual` Web 层渲染，深色主题靠 JS `setTheme()` 注入 CSS 变量。

三个根因（根因复核已通过）：

1. **深色 tips 配色取值不当** — `App.js` 深色分支 tips 背景 `rgba(42,42,42,0.8)` 与页面背景 `#252525`(37) 合成后约 41，仅差约 4 色阶近不可辨；边框/阴影取黑色，落在近黑背景上失效，tips 无视觉边界。
2. **CSS 变量无静态回退** — `--tips-*`/`--nav-hove-word-color` 全仓无 `:root` 默认值，仅在 `setTheme()` 运行时赋值。初始加载异步窗口（`App.js:170`/`web_window.cpp:1006`）或 `getTheme()` 返回 `"Null"`（`theme_proxy.cpp:36-43` → `App.js:682`）时 `var(--tips-*)` 回退 CSS 初始值 → 透明背景 + 继承黑文字。
3. **`ff02dc2` 修复不完整** — 该提交（显式关联本 bug）仅迁移 `.tooltip-wrapper`，其余 3 处 tooltip 规则（`index.scss` 的 `.tooltip-wp:after`、`.title-wrapper`，`main.scss` 的 `#main .tooltip-wp:after`）仍用共享 `--nav-hove-border-color` 且无主题化阴影。

## 修复方案

1. 校正深色 tips 配色：背景 `rgba(56,56,56,0.95)`（与页面明显区分、近不透明），边框 `rgba(255,255,255,0.12)`（浅色半透明，深色下可见），阴影 `rgba(0,0,0,0.45)`（加深）。
2. 补 `:root` 静态回退默认值（深色基调），兜底异步/Null 场景。
3. 统一 4 处 tooltip 规则到专用 `--tips-border-color`/`--tips-shadow-color` 并补主题化 `box-shadow`。
4. 同步更新编译产物 `web_dist/toManual/index.css`/`index.js`（运行时实际加载 web_dist）。

> 注：深色 tips 目标色值无 UI 设计稿，采用与页面背景有明显区分的保守深色配色，**待人工校验色值**。浅色主题取值未改动。

## 改动安全评估

纯 CSS/JS 样式改动，无逻辑/签名变更，无外部调用者影响，风险低。仅影响 tips/tooltip 视觉表现。

## 改动文件

- `src/web/toManual/js/App.js` — 深色 tips 配色取值
- `src/web/toManual/sass/main.scss` — `:root` 回退默认值 + `#main .tooltip-wp:after` 统一
- `src/web/toManual/sass/index.scss` — `.tooltip-wp:after`、`.title-wrapper` 统一
- `src/web_dist/toManual/index.css` / `index.js` — 编译产物同步

## Summary by Sourcery

Improve dark theme tooltip styling and resilience of theme-dependent CSS variables in the manual webview.

Bug Fixes:
- Correct dark-theme tips and tooltip colors, borders, and shadows to ensure readable contrast against the page background.
- Prevent tips-related CSS variables from falling back to transparent background and default text colors when theme initialization is delayed or returns Null.

Enhancements:
- Introduce :root fallback values for tips and navigation hover text color to provide consistent styling before runtime theme injection.
- Standardize all tooltip instances to use dedicated tips border and shadow CSS variables and apply a unified box-shadow.
- Regenerate the built web assets for the manual (index.css and index.js) to reflect the updated styling and theme variable usage.