### PR TITLE
fix(theme): adjust dark mode tooltip colors for support button

### DIFF
--- a/src/web/toManual/js/App.js
+++ b/src/web/toManual/js/App.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -607,7 +607,7 @@ class App extends React.Component {
                 document.documentElement.style.setProperty(`--nav-background-color`, '#282828');
                 document.documentElement.style.setProperty(`--nav-h2-word-color`, 'rgba(255, 255, 255, 0.85)');
                 document.documentElement.style.setProperty(`--nav-h3-word-color`, 'rgba(255, 255, 255, 0.7)');
-                document.documentElement.style.setProperty('--nav-hove-word-color', '#C0C6D4');
+                document.documentElement.style.setProperty('--nav-hove-word-color', '#FFFFFF');
                 document.documentElement.style.setProperty('--nav-hove-border-color', 'rgba(0, 0, 0, 0.3)');
                 //document.documentElement.style.setProperty(`--nav-hash-word-color`, '#0059D2');     //btnlist 改这行
                 document.documentElement.style.setProperty(`--article-read-word-color`, '#C0C6D4');
@@ -635,7 +635,7 @@ class App extends React.Component {
                 document.documentElement.style.setProperty(`--search-WikiSearch-color`, '#6D7C88');
                 document.documentElement.style.setProperty(`--search-itemTitle-word-color`, '#C0C6D4');
                 document.documentElement.style.setProperty(`--search-context-word-color`, '#6D7C88');
-                document.documentElement.style.setProperty(`--tips-background-color`, 'rgba(42, 42, 42, 0.8)');
+                document.documentElement.style.setProperty(`--tips-background-color`, '#141414');
                 document.documentElement.style.setProperty(`--tips-border-color`, 'rgba(0, 0, 0, 0.3)');
                 document.documentElement.style.setProperty('--tips-shadow-color', 'rgba(0, 0, 0, 0.2)');
             } else if ("LightType" == themeType) {

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -703,7 +703,7 @@ var App = function (_React$Component) {
                     document.documentElement.style.setProperty('--nav-background-color', '#282828');
                     document.documentElement.style.setProperty('--nav-h2-word-color', 'rgba(255, 255, 255, 0.85)');
                     document.documentElement.style.setProperty('--nav-h3-word-color', 'rgba(255, 255, 255, 0.7)');
-                    document.documentElement.style.setProperty('--nav-hove-word-color', '#C0C6D4');
+                    document.documentElement.style.setProperty('--nav-hove-word-color', '#FFFFFF');
                     document.documentElement.style.setProperty('--nav-hove-border-color', 'rgba(0, 0, 0, 0.3)');
                     //document.documentElement.style.setProperty(`--nav-hash-word-color`, '#0059D2');     //btnlist 改这行
                     document.documentElement.style.setProperty('--article-read-word-color', '#C0C6D4');
@@ -731,7 +731,7 @@ var App = function (_React$Component) {
                     document.documentElement.style.setProperty('--search-WikiSearch-color', '#6D7C88');
                     document.documentElement.style.setProperty('--search-itemTitle-word-color', '#C0C6D4');
                     document.documentElement.style.setProperty('--search-context-word-color', '#6D7C88');
-                    document.documentElement.style.setProperty('--tips-background-color', 'rgba(42, 42, 42, 0.8)');
+                    document.documentElement.style.setProperty('--tips-background-color', '#141414');
                     document.documentElement.style.setProperty('--tips-border-color', 'rgba(0, 0, 0, 0.3)');
                     document.documentElement.style.setProperty('--tips-shadow-color', 'rgba(0, 0, 0, 0.2)');
                 } else if ("LightType" == themeType) {


### PR DESCRIPTION
Change tooltip font color to #FFFFFF and background to #141414 in dark mode for better readability. Sync built web_dist output.

调整深色模式下"服务与支持"提示框字体颜色为#FFFFFF、背景为#141414，
提升可读性。同步编译产物 web_dist。

Log: 调整深色模式服务与支持提示框颜色
PMS: BUG-243239
Influence: 深色模式下"服务与支持"按钮 tooltip 字体及背景颜色调整，
提升显示效果。

## Summary by Sourcery

Improve dark-mode support-button tooltip contrast and synchronize the generated web output.

Bug Fixes:
- Improve dark-mode support-button tooltip readability by using white text on a dark #141414 background.

Chores:
- Synchronize the compiled web_dist output with the source changes.