### PR TITLE
fix: adjust dark theme text colors for better readability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,13 @@ endif ()
 project(deepin-manual)
 
 option(DMAN_RELEAE OFF "Install dman resources to system or not")
+option(OPT_BUILD_UT "Build unit tests" ON)
 
 add_subdirectory(src)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_subdirectory(tests)
+if (OPT_BUILD_UT)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_subdirectory(tests)
+    endif()
 endif()
 

--- a/src/web/toManual/js/App.js
+++ b/src/web/toManual/js/App.js
@@ -610,9 +610,9 @@ class App extends React.Component {
                 document.documentElement.style.setProperty('--nav-hove-word-color', '#FFFFFF');
                 document.documentElement.style.setProperty('--nav-hove-border-color', 'rgba(0, 0, 0, 0.3)');
                 //document.documentElement.style.setProperty(`--nav-hash-word-color`, '#0059D2');     //btnlist 改这行
-                document.documentElement.style.setProperty(`--article-read-word-color`, '#C0C6D4');
+                document.documentElement.style.setProperty(`--article-read-word-color`, '#FFFFFF');
                 document.documentElement.style.setProperty(`--article-read-h2-word-color`, '#0082FA');
-                document.documentElement.style.setProperty(`--article-table-text-color`, '#6D7C88');
+                document.documentElement.style.setProperty(`--article-table-text-color`, 'rgba(255, 255, 255, 0.5)');
                 document.documentElement.style.setProperty(`--article-table-border-color`, 'rgba(96, 96, 96, 0.5)');
                 document.documentElement.style.setProperty(`--article-table-cell-border-color`, 'rgba(96, 96, 96, 0.1)');
                 document.documentElement.style.setProperty(`--index-item-background-color`, 'rgba(255,255,255,0.05)');

--- a/src/web_dist/toManual/index.js
+++ b/src/web_dist/toManual/index.js
@@ -706,9 +706,9 @@ var App = function (_React$Component) {
                     document.documentElement.style.setProperty('--nav-hove-word-color', '#FFFFFF');
                     document.documentElement.style.setProperty('--nav-hove-border-color', 'rgba(0, 0, 0, 0.3)');
                     //document.documentElement.style.setProperty(`--nav-hash-word-color`, '#0059D2');     //btnlist 改这行
-                    document.documentElement.style.setProperty('--article-read-word-color', '#C0C6D4');
+                    document.documentElement.style.setProperty('--article-read-word-color', '#FFFFFF');
                     document.documentElement.style.setProperty('--article-read-h2-word-color', '#0082FA');
-                    document.documentElement.style.setProperty('--article-table-text-color', '#6D7C88');
+                    document.documentElement.style.setProperty('--article-table-text-color', 'rgba(255, 255, 255, 0.5)');
                     document.documentElement.style.setProperty('--article-table-border-color', 'rgba(96, 96, 96, 0.5)');
                     document.documentElement.style.setProperty('--article-table-cell-border-color', 'rgba(96, 96, 96, 0.1)');
                     document.documentElement.style.setProperty('--index-item-background-color', 'rgba(255,255,255,0.05)');


### PR DESCRIPTION
Update the article body text color from #C0C6D4 to #FFFFFF and table text color from #6D7C88 to rgba(255,255,255,0.5) in dark theme to improve contrast and readability. Also add OPT_BUILD_UT option to CMakeLists.txt to control unit test build.

调整深色主题下正文文字和表格文字颜色，提升可读性

Log: 调整深色主题下正文和表格文字颜色
PMS: BUG-243251
Influence: 深色主题下正文和表格的文字颜色显示

## Summary by Sourcery

Improve dark-theme text readability and make unit-test builds configurable.

Bug Fixes:
- Improve dark-theme readability by increasing article body text contrast and using a more legible table text color.

Build:
- Add an option to control whether unit tests are built, while retaining Debug-only test builds.